### PR TITLE
perf: drop hero LCP-blocking animations, fix contrast and duplicate a…

### DIFF
--- a/.vitepress/theme/HeroUnit.vue
+++ b/.vitepress/theme/HeroUnit.vue
@@ -297,8 +297,6 @@ html.dark .grid-overlay {
 
 /* Left Content */
 .heroContent {
-  opacity: 0;
-  animation: fadeInLeft 1s ease-out 0.2s forwards;
 }
 
 @keyframes fadeInLeft {
@@ -319,18 +317,11 @@ html.dark .grid-overlay {
 }
 
 .title-line {
-  opacity: 0;
-  transform: translateY(20px);
-  animation: slideUp 0.6s ease-out forwards;
   background: -webkit-linear-gradient(120deg, #392C91 30%, #13B0EE 70%);
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
-
-.title-line:nth-child(1) { animation-delay: 0.4s; }
-.title-line:nth-child(2) { animation-delay: 0.6s; }
-.title-line:nth-child(3) { animation-delay: 0.8s; }
 
 @keyframes slideUp {
   to {
@@ -344,8 +335,6 @@ html.dark .grid-overlay {
   line-height: 1.6;
   color: #4b5563;
   margin-bottom: 16px;
-  opacity: 0;
-  animation: fadeIn 0.6s ease-out 1s forwards;
 }
 
 html.dark .tagline {
@@ -354,7 +343,6 @@ html.dark .tagline {
 
 .tagline--accent {
   margin-top: 4px;
-  animation-delay: 1.15s;
 }
 
 @keyframes fadeIn {
@@ -363,9 +351,6 @@ html.dark .tagline {
 
 /* CTA Button with Shine Animation - FIXED TEXT CENTERING */
 .cta-button {
-  opacity: 0;
-  transform: translateY(10px);
-  animation: slideUp 0.6s ease-out 1.2s forwards;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
   box-shadow: 0 8px 24px rgba(19, 176, 238, 0.25) !important;
   position: relative;
@@ -426,8 +411,6 @@ html.dark .cta-button:hover {
   flex-wrap: wrap;
   gap: 10px;
   margin-top: 20px;
-  opacity: 0;
-  animation: fadeIn 0.6s ease-out 1.1s forwards;
 }
 
 .highlight-item {
@@ -453,8 +436,6 @@ html.dark .highlight-item {
   aspect-ratio: 1 / 1;
   margin: 0 auto;
   height: auto;
-  opacity: 0;
-  animation: fadeInRight 1s ease-out 0.4s forwards;
 }
 
 @keyframes fadeInRight {

--- a/.vitepress/theme/TemplateShowcase.vue
+++ b/.vitepress/theme/TemplateShowcase.vue
@@ -115,10 +115,10 @@ function getCardStyle(index) {
       return { transform: 'translateX(-50%) scale(1)', opacity: '1', zIndex: 3, pointerEvents: 'auto' }
     }
     if (offset === 1) {
-      return { transform: 'translateX(20%) scale(0.85)', opacity: '0.55', zIndex: 1, pointerEvents: 'auto', cursor: 'pointer' }
+      return { transform: 'translateX(20%) scale(0.85)', opacity: '1', zIndex: 1, pointerEvents: 'auto', cursor: 'pointer' }
     }
     if (offset === total - 1) {
-      return { transform: 'translateX(-120%) scale(0.85)', opacity: '0.55', zIndex: 1, pointerEvents: 'auto', cursor: 'pointer' }
+      return { transform: 'translateX(-120%) scale(0.85)', opacity: '1', zIndex: 1, pointerEvents: 'auto', cursor: 'pointer' }
     }
     if (offset === 2) {
       return { transform: 'translateX(80%) scale(0.7)', opacity: '0', zIndex: 0, pointerEvents: 'none' }
@@ -211,6 +211,7 @@ onBeforeUnmount(() => {
         v-for="(tpl, i) in templates"
         :key="tpl.src"
         class="ts-card"
+        :class="{ 'ts-card--center': isCenter(i) }"
         :style="getCardStyle(i)"
         :aria-hidden="!isCenter(i)"
         @click="onCardClick(i)"
@@ -359,6 +360,15 @@ onBeforeUnmount(() => {
   object-fit: cover;
   object-position: top;
   display: block;
+  transition: filter 0.4s ease;
+}
+
+.ts-card:not(.ts-card--center) .ts-img {
+  filter: brightness(0.78) saturate(0.7);
+}
+
+.ts-root--dark .ts-card:not(.ts-card--center) .ts-img {
+  filter: brightness(0.6) saturate(0.7);
 }
 
 /* ---- Card footer ---- */

--- a/for/marketing-agencies/AgencyAnalytics.vue
+++ b/for/marketing-agencies/AgencyAnalytics.vue
@@ -531,7 +531,7 @@ html.dark .dash-views { background: #0f172a; }
   border: none;
   background: transparent;
   border-radius: 6px;
-  color: #475569;
+  color: #334155;
   cursor: pointer;
   transition: all 0.18s ease;
   white-space: nowrap;
@@ -561,7 +561,7 @@ html.dark .dash-view-btn.active { background: #1e293b; color: #f1f5f9; }
   border: 1px solid #e2e8f0;
   background: transparent;
   border-radius: 5px;
-  color: #475569;
+  color: #334155;
   cursor: pointer;
   transition: all 0.15s ease;
   text-transform: uppercase;
@@ -619,19 +619,19 @@ html.dark .dash-meta { border-bottom-color: #334155; }
 
 .dash-date {
   font-size: 11px;
-  color: #475569;
+  color: #334155;
 }
 
 .dash-metric-label {
   font-size: 11px;
-  color: #475569;
+  color: #334155;
   display: flex;
   align-items: center;
   gap: 3px;
   cursor: pointer;
 }
 
-.dash-metric-value { color: #0e7fa8; font-weight: 700; }
+.dash-metric-value { color: #0c6a8d; font-weight: 700; }
 
 /* Stats row */
 .dash-stats {
@@ -658,7 +658,7 @@ html.dark .dash-stat { border-right-color: #334155; }
   display: block;
   font-size: 10px;
   font-weight: 600;
-  color: #475569;
+  color: #334155;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   white-space: nowrap;

--- a/index.md
+++ b/index.md
@@ -927,10 +927,7 @@ const { isDark } = useData()
 
 <!-- 7. INTEGRATIONS -->
 <div class="stripe stripe--blue stripe--integrations"><div class="stripe-inner">
-<section class="value-prop" role="region" aria-labelledby="integrations-heading">
-  <h2 id="integrations-heading" class="visually-hidden">Platform integrations</h2>
-  <Integration :is-dark="isDark" />
-</section>
+<Integration :is-dark="isDark" />
 </div></div>
 
 <!-- 8. FOUNDER -->


### PR DESCRIPTION
…ria id

- HeroUnit: remove opacity:0 + delayed animations on title-line, tagline, cta-button, heroContent, hero-highlights, heroVisual. LCP element no longer waits 0.4-1.2s for CSS animation.
- TemplateShowcase: keep side cards opaque, dim image via filter so ts-card-title contrast scan passes.
- AgencyAnalytics: bump #475569 -> #334155 and #0e7fa8 -> #0c6a8d for AA contrast on dashboard text.
- index.md: drop redundant integrations-heading h2 (duplicate of the one in Integration.vue).