### PR TITLE
feat: add ToolSwitcher component for email diagnostic tools navigation

### DIFF
--- a/.vitepress/theme/ToolsCategoryGrid.vue
+++ b/.vitepress/theme/ToolsCategoryGrid.vue
@@ -1,0 +1,141 @@
+<script setup>
+defineProps({
+  tools: { type: Array, required: true }, // [{ name, desc, href, iconPaths, tag? }]
+})
+</script>
+
+<template>
+  <div class="tools-grid">
+    <a
+      v-for="tool in tools"
+      :key="tool.href"
+      :href="tool.href"
+      class="tool-card"
+    >
+      <div class="card-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" v-html="tool.iconPaths" />
+      </div>
+      <div class="card-body">
+        <div class="card-heading">
+          <h3 class="card-name">{{ tool.name }}</h3>
+          <span v-if="tool.tag" class="card-tag">{{ tool.tag }}</span>
+        </div>
+        <p class="card-desc">{{ tool.desc }}</p>
+      </div>
+      <div class="card-link" aria-hidden="true">
+        Open tool
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="5" y1="12" x2="19" y2="12"/>
+          <polyline points="12 5 19 12 12 19"/>
+        </svg>
+      </div>
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.tools-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin: 2rem 0;
+}
+
+.tool-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  text-decoration: none !important;
+  color: inherit;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+  cursor: pointer;
+}
+
+.tool-card:hover {
+  border-color: rgba(19, 176, 238, 0.5);
+  box-shadow: 0 8px 28px rgba(19, 176, 238, 0.15);
+  transform: translateY(-3px);
+}
+
+html.dark .tool-card:hover {
+  box-shadow: 0 8px 28px rgba(19, 176, 238, 0.22);
+}
+
+.card-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(19, 176, 238, 0.12), rgba(57, 44, 145, 0.1));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #13B0EE;
+  flex-shrink: 0;
+  transition: background 0.25s ease;
+}
+
+.tool-card:hover .card-icon {
+  background: linear-gradient(135deg, rgba(19, 176, 238, 0.22), rgba(57, 44, 145, 0.18));
+}
+
+.card-body { flex: 1; }
+
+.card-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 6px;
+}
+
+.card-name {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  margin: 0;
+  padding: 0;
+  border: none !important;
+  line-height: 1.3;
+}
+
+.card-tag {
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #392C91;
+  background: rgba(57, 44, 145, 0.1);
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+html.dark .card-tag { color: #b3a4ff; background: rgba(179, 164, 255, 0.15); }
+
+.card-desc {
+  font-size: 13.5px;
+  color: var(--vp-c-text-2);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.card-link {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #13B0EE;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.tool-card:hover .card-link { opacity: 1; }
+
+@media (max-width: 640px) {
+  .tools-grid { grid-template-columns: 1fr; }
+}
+</style>

--- a/.vitepress/theme/ToolsHome.vue
+++ b/.vitepress/theme/ToolsHome.vue
@@ -1,0 +1,192 @@
+<script setup>
+const categories = [
+  {
+    name: 'Email Deliverability Tools',
+    desc: 'Check DMARC, SPF, DKIM, and MX records to prevent spoofing and fix inbox placement issues.',
+    href: '/tools/deliverability/index',
+    count: '5 tools',
+    iconPaths: `<path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22 6 12 13 2 6"/>`,
+  },
+  {
+    name: 'Email Content Tools',
+    desc: 'Test links and validate your HTML email content before you hit send.',
+    href: '/tools/content/index',
+    count: '1 tool',
+    iconPaths: `<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>`,
+  },
+]
+</script>
+
+<template>
+  <div class="tools-home">
+    <div class="tools-hero">
+      <h1 class="hero-title">Free Tools by BlueFox Email</h1>
+      <p class="hero-subtitle">
+        A growing toolbox of free utilities for email authentication and deliverability.
+        No signup required.
+      </p>
+    </div>
+
+    <div class="category-grid">
+      <a v-for="cat in categories" :key="cat.href" :href="cat.href" class="category-card">
+        <div class="category-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" v-html="cat.iconPaths" />
+        </div>
+        <div class="category-body">
+          <div class="category-heading">
+            <h2 class="category-name">{{ cat.name }}</h2>
+            <span class="category-count">{{ cat.count }}</span>
+          </div>
+          <p class="category-desc">{{ cat.desc }}</p>
+        </div>
+        <div class="category-link" aria-hidden="true">
+          Explore
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="5" y1="12" x2="19" y2="12"/>
+            <polyline points="12 5 19 12 12 19"/>
+          </svg>
+        </div>
+      </a>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tools-home { width: 100%; }
+
+.tools-hero {
+  text-align: center;
+  padding: 3.5rem 1.5rem 1rem;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.hero-title {
+  font-size: 2.25rem;
+  font-weight: 800;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  border: none !important;
+  background: linear-gradient(135deg, #13B0EE, #392C91);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+  font-size: 1.05rem;
+  color: var(--vp-c-text-2);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.category-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+  max-width: 900px;
+  margin: 2.5rem auto 3rem;
+  padding: 0 1.5rem;
+}
+
+.category-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 28px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 18px;
+  text-decoration: none !important;
+  color: inherit;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+  cursor: pointer;
+}
+
+.category-card:hover {
+  border-color: rgba(19, 176, 238, 0.5);
+  box-shadow: 0 10px 32px rgba(19, 176, 238, 0.16);
+  transform: translateY(-3px);
+}
+
+html.dark .category-card:hover {
+  box-shadow: 0 10px 32px rgba(19, 176, 238, 0.24);
+}
+
+.category-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(19, 176, 238, 0.14), rgba(57, 44, 145, 0.12));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #13B0EE;
+  flex-shrink: 0;
+  transition: background 0.25s ease;
+}
+
+.category-card:hover .category-icon {
+  background: linear-gradient(135deg, rgba(19, 176, 238, 0.24), rgba(57, 44, 145, 0.2));
+}
+
+.category-body { flex: 1; }
+
+.category-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 8px;
+}
+
+.category-name {
+  font-size: 19px;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  margin: 0;
+  padding: 0;
+  border: none !important;
+  line-height: 1.3;
+}
+
+.category-count {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #392C91;
+  background: rgba(57, 44, 145, 0.1);
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+html.dark .category-count { color: #b3a4ff; background: rgba(179, 164, 255, 0.15); }
+
+.category-desc {
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.category-link {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: #13B0EE;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.category-card:hover .category-link { opacity: 1; }
+
+@media (max-width: 640px) {
+  .category-grid { grid-template-columns: 1fr; margin: 2rem auto; }
+  .hero-title { font-size: 1.75rem; }
+  .tools-hero { padding: 2.5rem 1.25rem 0.5rem; }
+}
+</style>

--- a/.vitepress/theme/free-tools/DkimChecker.vue
+++ b/.vitepress/theme/free-tools/DkimChecker.vue
@@ -4,32 +4,41 @@ import { checkDkim } from '../../../connectors/bluefoxEmailToolsApi.js'
 import { isSessionValid } from '../../../connectors/turnstileSession.js'
 import { syncWithUrl, loadFromUrl } from './helpers/urlSync.js'
 import Turnstile from './Turnstile.vue'
+import SignalIcon from './SignalIcon.vue'
+import ToolSwitcher from './ToolSwitcher.vue'
 
-// ---- VARIABLES ----
 const DEFAULT_SELECTOR = 'default'
 const DKIM_TAG_DESCRIPTIONS = {
   v: "Version (always 'DKIM1').",
   k: "Key type (e.g., 'rsa').",
-  p: "Public key for signature verification.",
-  s: "Service type for this key.",
-  h: "Allowed hash algorithms.",
-  t: "DKIM flags.",
-  n: "Free-form notes."
+  p: 'Public key for signature verification.',
+  s: 'Service type for this key.',
+  h: 'Allowed hash algorithms.',
+  t: 'DKIM flags.',
+  n: 'Free-form notes.',
 }
 
-const domain = ref('')
-const selector = ref('')
-const loading = ref(false)
-const result = ref(null)
+const domain       = ref('')
+const selector     = ref('')
+const loading      = ref(false)
+const result       = ref(null)
 const errorMessage = ref('')
 
-// Turnstile state
-const turnstileRef = ref(null)
+const turnstileRef   = ref(null)
 const turnstileToken = ref('')
+const guessedSelector = ref(false)
+const resultsRef = ref(null)
 
-const isFormDisabled = computed(() =>
-  loading.value
-)
+const isFormDisabled = computed(() => loading.value)
+
+const TRUNCATE_AT = 40
+
+function truncateMiddle(value) {
+  if (value.length <= TRUNCATE_AT) return value
+  const head = value.slice(0, 20)
+  const tail = value.slice(-16)
+  return `${head}…${tail}`
+}
 
 const dkimTags = computed(() => {
   const record = result.value?.rawRecord || result.value?.record || ''
@@ -39,22 +48,45 @@ const dkimTags = computed(() => {
     .filter(Boolean)
     .map(pair => {
       const [tag, ...rest] = pair.split('=')
+      const value = rest.join('=').trim()
       return {
         tag: tag.trim(),
-        value: rest.join('=').trim(),
-        description: DKIM_TAG_DESCRIPTIONS[tag.trim()] || ''
+        value,
+        displayValue: truncateMiddle(value),
+        truncated: value.length > TRUNCATE_AT,
+        description: DKIM_TAG_DESCRIPTIONS[tag.trim()] || '',
       }
     })
 })
 
-// ---- FUNCTIONS ----
-function onTurnstileVerified(token) {
-  turnstileToken.value = token
+const copiedTag = ref('')
+
+async function copyTagValue(tag) {
+  try {
+    await navigator.clipboard.writeText(tag.value)
+    copiedTag.value = tag.tag
+    setTimeout(() => { if (copiedTag.value === tag.tag) copiedTag.value = '' }, 1500)
+  } catch {
+    /* clipboard unavailable */
+  }
 }
 
-function onTurnstileInvalid() {
-  turnstileToken.value = ''
-}
+const keyTypeSignal = computed(() => {
+  const k = dkimTags.value.find(t => t.tag === 'k')?.value?.toLowerCase() || 'rsa'
+  return { label: k.toUpperCase(), level: 'muted', icon: 'dot' }
+})
+
+const keyLengthSignal = computed(() => {
+  const p = dkimTags.value.find(t => t.tag === 'p')?.value
+  if (!p) return null
+  const approxBits = Math.floor((p.length * 6) / 8) * 8
+  if (approxBits >= 2048) return { label: `~${approxBits} bit`, level: 'strong', icon: 'check' }
+  if (approxBits >= 1024) return { label: `~${approxBits} bit`, level: 'medium', icon: 'minus' }
+  return { label: `~${approxBits} bit`, level: 'weak', icon: 'alert' }
+})
+
+function onTurnstileVerified(token) { turnstileToken.value = token }
+function onTurnstileInvalid()       { turnstileToken.value = '' }
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -66,20 +98,16 @@ function validateInputs() {
     errorMessage.value = 'Please enter a domain name'
     return false
   }
-
   return true
 }
 
 async function checkDkimHandler() {
-  result.value = null
-  loading.value = true
+  result.value       = null
+  loading.value       = true
   errorMessage.value = ''
 
   try {
-    if (!validateInputs()) {
-      loading.value = false
-      return
-    }
+    if (!validateInputs()) { loading.value = false; return }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
@@ -88,822 +116,597 @@ async function checkDkimHandler() {
     const data = await checkDkim({
       domain: domain.value,
       selector: selector.value || DEFAULT_SELECTOR,
-      turnstileToken: turnstileToken.value
+      turnstileToken: turnstileToken.value,
     })
 
     result.value = {
-      valid: true,
-      domain: data.result.domain || domain.value,
+      valid:    true,
+      domain:   data.result.domain || domain.value,
       selector: data.result.selector || selector.value,
-      record: data.result.rawRecord || data.result.record,
+      record:    data.result.rawRecord || data.result.record,
       rawRecord: data.result.rawRecord || data.result.record,
       warnings: data.result.warnings || [],
       recommendations: data.result.recommendations || [],
-      score: data.result.score
+      score: data.result.score,
     }
 
     resetTurnstile()
-
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) {
-      resetTurnstile()
-    }
+    if (err.status === 401) resetTurnstile()
   } finally {
     loading.value = false
   }
 }
 
-// ---- WATCHES ----
-watch([domain, selector], () => {
-  syncWithUrl({ domain: domain.value, selector: selector.value })
-})
+watch([domain, selector], () => syncWithUrl({ domain: domain.value, selector: selector.value }))
 
-// ---- LIFECYCLE ----
 onMounted(async () => {
+  const urlParams = new URLSearchParams(window.location.search)
+
   loadFromUrl({ domain, selector })
-
-  if (!selector.value) {
-    selector.value = DEFAULT_SELECTOR
-  }
-
+  if (!selector.value) selector.value = DEFAULT_SELECTOR
   await nextTick()
+
+  if (urlParams.get('run') === '1' && domain.value) {
+    if (urlParams.get('selector') === 'google') guessedSelector.value = true
+    await turnstileRef.value?.whenReady()
+    await checkDkimHandler()
+    await nextTick()
+    resultsRef.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
 })
 </script>
 
 <template>
   <div class="dkim-checker">
-    <!-- ── FORM ── -->
-    <div class="tool-form">
-      <form @submit.prevent="checkDkimHandler">
-        <!-- Domain -->
-        <div class="form-group">
-          <label for="domain">Domain:</label>
+
+    <ToolSwitcher :domain="domain" />
+
+    <!-- ── Inline form ── -->
+    <div class="search-bar" :class="{ 'has-result': result }">
+      <form class="search-form" @submit.prevent="checkDkimHandler">
+        <div class="search-input-wrap">
+          <span class="search-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+            </svg>
+          </span>
           <input
             id="domain"
             v-model="domain"
             type="text"
             placeholder="example.com"
             :disabled="loading"
+            autocomplete="off"
+            spellcheck="false"
             required
           />
-          <small class="form-help">
-            Enter the domain name you want to check for DKIM records
-          </small>
+          <button
+            v-if="domain && !loading"
+            type="button"
+            class="search-clear"
+            aria-label="Clear domain"
+            @click="domain = ''"
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
         </div>
-
-        <!-- Selector -->
-        <div class="form-group">
-          <label for="selector">DKIM Selector:</label>
+        <div class="selector-input-wrap">
+          <span class="selector-prefix">selector:</span>
           <input
             id="selector"
             v-model="selector"
             type="text"
             placeholder="default"
             :disabled="loading"
-          />
-          <small class="form-help">
-            Most common selectors: <code>default</code>, <code>google</code>, <code>mail</code>
-          </small>
-        </div>
-
-        <!-- Verification -->
-        <div class="form-group">
-          <Turnstile
-            ref="turnstileRef"
-            @verified="onTurnstileVerified"
-            @expired="onTurnstileInvalid"
-            @error="onTurnstileInvalid"
+            autocomplete="off"
+            spellcheck="false"
           />
         </div>
-
-        <!-- Submit -->
-        <button
-          type="submit"
-          class="check-btn"
-          :disabled="isFormDisabled"
-        >
-          <span v-if="loading" class="btn-loading">
-            <div class="loading-spinner"></div>
-            Checking...
-          </span>
-          <span v-else>Check DKIM Record</span>
+        <Turnstile
+          ref="turnstileRef"
+          class="turnstile-inline"
+          :class="{ 'turnstile-collapsed': result }"
+          @verified="onTurnstileVerified"
+          @expired="onTurnstileInvalid"
+          @error="onTurnstileInvalid"
+        />
+        <button type="submit" class="search-btn" :disabled="isFormDisabled">
+          <span v-if="loading" class="btn-loading"><span class="spinner"></span></span>
+          <span v-else>Check DKIM</span>
         </button>
       </form>
+      <p v-if="guessedSelector" class="form-hint form-hint-notice">
+        Guessed selector <code>google</code> from the switcher. Not right? Change it in the <strong>selector</strong> field above.
+      </p>
+      <p v-else class="form-hint">Common selectors: <code>default</code>, <code>google</code>, <code>selector1</code>, <code>mail</code></p>
     </div>
 
-    <!-- Error -->
-    <div v-if="errorMessage" class="error-section">
-      <p class="error-message">{{ errorMessage }}</p>
+    <!-- ── Error ── -->
+    <div v-if="errorMessage" class="error-pill">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      {{ errorMessage }}
     </div>
 
-    <!-- Results -->
-    <div v-if="result" class="result-section">
-      <h3>DKIM Check Results</h3>
+    <!-- ── Results ── -->
+    <div v-if="result" class="results" ref="resultsRef">
 
-      <div class="status-box">
-        <p>
-          <strong>
-            {{ result.valid ? 'DKIM Record Found' : 'DKIM Record Missing or Invalid' }}
-          </strong>
-        </p>
-        <p v-if="result.score">
-          <strong>Security Score:</strong>
-          {{ result.score.value }}/{{ result.score.outOf }} ({{ result.score.level }})
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Security assessment based on key strength, algorithm choice, and record configuration.</span>
-          </span>
-        </p>
-      </div>
-
-      <div class="info-section">
-        <h4>
-          Basic Information
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Core details about the DKIM record found for this domain and selector.</span>
-          </span>
-        </h4>
-        <p><strong>Domain:</strong> {{ result.domain }}</p>
-        <p>
-          <strong>Selector:</strong> {{ result.selector }}
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">The DKIM selector used to locate the public key. Different services often use different selectors.</span>
-          </span>
-        </p>
-        <p><strong>DKIM Record:</strong></p>
-        <div class="record-display">
-          <code class="dkim-record">{{ result.record }}</code>
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">The complete DKIM TXT record retrieved from DNS at [selector]._domainkey.[domain].</span>
-          </span>
+      <!-- Hero -->
+      <div class="hero" :class="result.valid && result.record ? 'hero-pass' : 'hero-fail'">
+        <div class="hero-icon" :class="result.valid && result.record ? 'icon-pass' : 'icon-fail'">
+          <svg v-if="result.valid && result.record" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          <svg v-else width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </div>
+        <div class="hero-text">
+          <h2 class="hero-title">{{ result.record ? 'DKIM Record Found' : 'DKIM Record Missing' }}</h2>
+          <p class="hero-domain">{{ result.selector }}._domainkey.{{ result.domain }}</p>
+        </div>
+        <div v-if="result.score" class="hero-score">
+          <span class="score-num">{{ result.score.value }}<span class="score-denom">/{{ result.score.outOf }}</span></span>
+          <span class="score-label" :class="'score-' + result.score.level?.toLowerCase()">{{ result.score.level }}</span>
         </div>
       </div>
 
-      <div v-if="dkimTags.length" class="dkim-table-section">
-        <h4>
-          DKIM Record Breakdown
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Each component of the DKIM record explained. These tags define the public key and signature parameters.</span>
-          </span>
-        </h4>
-        <div class="table-container">
-          <table class="dkim-table">
-            <thead>
-              <tr>
-                <th class="tag-col">Tag</th>
-                <th class="value-col">Value</th>
-                <th class="desc-col">Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="tag in dkimTags" :key="tag.tag">
-                <td class="tag-cell">{{ tag.tag }}</td>
-                <td class="value-cell">{{ tag.value }}</td>
-                <td class="desc-cell">{{ tag.description }}</td>
-              </tr>
-            </tbody>
-          </table>
+      <!-- Signals grid -->
+      <div v-if="result.record" class="signals-grid">
+        <div class="signal" :class="'signal-' + keyTypeSignal.level">
+          <span class="signal-icon"><SignalIcon :name="keyTypeSignal.icon" /></span>
+          <span class="signal-name">Key Type</span>
+          <span class="signal-value">{{ keyTypeSignal.label }}</span>
+        </div>
+        <div v-if="keyLengthSignal" class="signal" :class="'signal-' + keyLengthSignal.level">
+          <span class="signal-icon"><SignalIcon :name="keyLengthSignal.icon" /></span>
+          <span class="signal-name">Key Length</span>
+          <span class="signal-value">{{ keyLengthSignal.label }}</span>
+        </div>
+        <div class="signal signal-muted">
+          <span class="signal-icon"><SignalIcon name="dot" /></span>
+          <span class="signal-name">Tags</span>
+          <span class="signal-value">{{ dkimTags.length }}</span>
         </div>
       </div>
 
-      <div v-if="result.warnings?.length" class="section warnings-section">
-        <h4>Warnings</h4>
-        <ul>
-          <li v-for="warning in result.warnings" :key="warning">
-            {{ warning }}
-          </li>
-        </ul>
+      <!-- Alerts -->
+      <div v-if="result.warnings?.length" class="alert alert-warn">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <ul><li v-for="w in result.warnings" :key="w">{{ w }}</li></ul>
       </div>
 
-      <div
-        v-if="result.recommendations?.length"
-        class="section recommendations-section"
-      >
-        <h4>Recommendations</h4>
-        <ul>
-          <li v-for="rec in result.recommendations" :key="rec">
-            {{ rec }}
-          </li>
-        </ul>
+      <div v-if="result.recommendations?.length" class="alert alert-tip">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <ul><li v-for="r in result.recommendations" :key="r">{{ r }}</li></ul>
       </div>
+
+      <!-- Expert disclosures -->
+      <div class="disclosures">
+        <details class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">Raw DKIM record</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <code class="raw-record">{{ result.record }}</code>
+          </div>
+        </details>
+
+        <details v-if="dkimTags.length" class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">Tag breakdown</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <div class="tag-list">
+              <div class="tag-row" v-for="tag in dkimTags" :key="tag.tag">
+                <span class="tag-key">{{ tag.tag }}</span>
+                <div class="tag-main">
+                  <div class="tag-value-line">
+                    <code class="tag-value">{{ tag.displayValue }}</code>
+                    <button
+                      v-if="tag.truncated"
+                      type="button"
+                      class="tag-copy-btn"
+                      :class="{ copied: copiedTag === tag.tag }"
+                      :aria-label="`Copy ${tag.tag} tag value`"
+                      @click="copyTagValue(tag)"
+                    >
+                      <svg v-if="copiedTag === tag.tag" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                      <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                      <span>{{ copiedTag === tag.tag ? 'Copied' : 'Copy' }}</span>
+                    </button>
+                  </div>
+                  <p class="tag-desc">{{ tag.description }}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </details>
+      </div>
+
     </div>
   </div>
 </template>
 
 <style scoped>
 .dkim-checker {
-  max-width: 800px;
+  max-width: 720px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 1rem 3rem;
 }
 
-/* Form Styles */
-.tool-form {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 12px;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
+/* Search bar */
+.search-bar { margin: 2rem 0 1.5rem; transition: margin 0.2s; }
+.search-bar.has-result { margin: 0 0 1rem; }
+
+.search-form {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
 }
 
-.form-group {
-  margin-bottom: 1.5rem;
+.search-input-wrap {
+  flex: 1.5;
+  min-width: 200px;
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
-.form-group label {
-  display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--vp-c-text-1, #374151);
-  font-size: 0.9rem;
+.search-icon {
+  position: absolute;
+  left: 0.875rem;
+  color: var(--vp-c-text-3, #9ca3af);
+  display: flex;
+  pointer-events: none;
 }
 
-.form-group input {
+.search-input-wrap input {
   width: 100%;
-  padding: 0.875rem 1rem;
-  border: 2px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 8px;
+  padding: 0.75rem 2.25rem 0.75rem 2.5rem;
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
   font-size: 1rem;
-  transition: border-color 0.2s ease;
+  background: var(--vp-c-bg, #fff);
+  color: var(--vp-c-text-1, #111827);
+  transition: border-color 0.15s, box-shadow 0.15s, padding 0.2s;
   box-sizing: border-box;
-  background: var(--vp-c-bg, #ffffff);
-  color: var(--vp-c-text-1, #374151);
 }
 
-.form-group input:focus {
+.has-result .search-input-wrap input,
+.has-result .selector-input-wrap input { padding-top: 0.5rem; padding-bottom: 0.5rem; font-size: 0.9rem; }
+
+.search-input-wrap input:focus,
+.selector-input-wrap input:focus {
   outline: none;
   border-color: var(--vp-c-brand);
-  box-shadow: 0 0 0 3px rgba(19, 176, 238, 0.1);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
 }
 
-.form-group input:disabled {
+.search-input-wrap input:disabled,
+.selector-input-wrap input:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.search-clear {
+  position: absolute;
+  right: 0.625rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px; height: 20px;
+  border: none;
   background: var(--vp-c-bg-mute, #f1f5f9);
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.form-help {
-  display: block;
-  margin-top: 0.5rem;
   color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-style: italic;
-  line-height: 1.4;
+  border-radius: 50%;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
 }
 
-.form-help code {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  padding: 0.125rem 0.25rem;
-  border-radius: 3px;
-  font-size: 0.8rem;
-}
+.search-clear:hover { background: var(--vp-c-bg-soft, #e5e7eb); color: var(--vp-c-text-1, #111827); }
 
-/* CAPTCHA Styles */
-.captcha-expired-message {
-  background: #fff3cd;
-  border: 1px solid #ffc107;
-  color: #856404;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1rem;
-  font-size: 0.875rem;
-}
-
-.captcha-container {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.captcha-image-container {
+.selector-input-wrap {
   flex: 1;
-  min-height: 50px;
+  min-width: 150px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  background: #ffffff;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 6px;
-  padding: 0.5rem;
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
+  background: var(--vp-c-bg, #fff);
+  padding: 0 0.875rem;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.captcha-loading,
-.captcha-placeholder {
-  color: #6b7280;
-  font-style: italic;
-  text-align: center;
-}
-
-.load-captcha-btn {
-  background: var(--vp-c-brand);
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.875rem;
-  transition: background-color 0.2s ease;
-}
-
-.load-captcha-btn:hover {
-  background: var(--vp-c-brand-light);
-}
-
-.refresh-captcha-btn {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  padding: 0.5rem;
-  border-radius: 6px;
-  cursor: pointer;
-  width: 2.5rem;
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
-}
-
-.refresh-captcha-btn:hover:not(:disabled) {
-  background: var(--vp-c-bg, #ffffff);
+.selector-input-wrap:focus-within {
   border-color: var(--vp-c-brand);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
 }
 
-.refresh-captcha-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+.selector-prefix {
+  font-size: 0.8rem;
+  color: var(--vp-c-text-3, #9ca3af);
+  white-space: nowrap;
 }
 
-.refresh-captcha-btn img {
-  width: 16px;
-  height: 16px;
-}
-
-.captcha-help {
-  display: block;
-  margin-top: 0.5rem;
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-style: italic;
-}
-
-/* Button */
-.check-btn {
-  background: var(--vp-c-brand);
-  color: #ffffff;
-  padding: 0.875rem 2rem;
+.selector-input-wrap input {
   border: none;
-  border-radius: 8px;
-  cursor: pointer;
+  background: transparent;
+  padding: 0.75rem 0 0.75rem 0.375rem;
   font-size: 1rem;
-  font-weight: 600;
-  transition: all 0.2s ease;
+  color: var(--vp-c-text-1, #111827);
   width: 100%;
-  box-shadow: 0 2px 4px rgba(19, 176, 238, 0.2);
+  min-width: 0;
 }
 
-.check-btn:hover:not(:disabled) {
-  background: var(--vp-c-brand-light);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(19, 176, 238, 0.25);
+.selector-input-wrap input:focus { outline: none; box-shadow: none; }
+
+.turnstile-inline {
+  flex-shrink: 0;
+  transition: opacity 0.2s, max-width 0.2s, max-height 0.2s, margin 0.2s;
+  overflow: hidden;
 }
 
-.check-btn:active:not(:disabled) {
-  background: var(--vp-c-brand-dark);
-  transform: translateY(0);
-}
-
-.check-btn:disabled {
-  background: var(--vp-c-bg-mute, #9ca3af);
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-.btn-loading {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  justify-content: center;
-}
-
-.loading-spinner {
-  width: 12px;
-  height: 12px;
-  border: 1.5px solid rgba(255, 255, 255, 0.3);
-  border-top: 1.5px solid #ffffff;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-
-/* Error Section */
-.error-section {
-  background: var(--vp-danger-soft, #f8d7da);
-  color: var(--vp-c-danger-1, #721c24);
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
-  border: 1px solid var(--vp-c-danger-2, #f5c6cb);
-}
-
-.error-message {
-  margin: 0;
-  font-weight: 500;
-}
-
-/* Results Section */
-.result-section {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.result-section h3 {
-  margin: 0 0 1.5rem 0;
-  color: var(--vp-c-text-1, #1a202c);
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.status-box {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  padding: 1.25rem;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 8px;
-  margin-bottom: 1.5rem;
-}
-
-.status-box p {
-  margin: 0.5rem 0;
-  font-size: 1rem;
-}
-
-/* Info Section */
-.info-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.info-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.info-section p {
-  margin: 0.75rem 0;
-  color: var(--vp-c-text-2, #4a5568);
-  line-height: 1.6;
-}
-
-.record-display {
-  margin-top: 0.5rem;
-  position: relative;
-}
-
-.dkim-record {
-  display: block;
-  padding: 0.75rem;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 6px;
-  font-family: var(--vp-font-family-mono, 'Courier New', monospace);
-  font-size: 0.875rem;
-  word-break: break-all;
-  white-space: pre-wrap;
-  line-height: 1.4;
-  color: var(--vp-c-text-1, #333);
-  margin-right: 2rem;
-}
-
-/* Info tip styles */
-.info-tip {
-  display: inline-block;
-  margin-left: .3rem;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1rem;
-  text-align: center;
-  border-radius: 50%;
-  background: var(--vp-c-brand);
-  color: #fff;
-  font-size: .675rem;
-  cursor: help;
-  position: relative;
-  vertical-align: middle;
-}
-
-.info-tip-pop {
-  opacity: 0;
+.turnstile-inline.turnstile-collapsed {
+  opacity: 0; max-width: 0; max-height: 0;
   pointer-events: none;
   position: absolute;
-  left: 50%;
-  top: calc(100% + 8px);
-  transform: translateX(-50%);
-  width: max-content;
-  max-width: min(300px, 90vw);
-  padding: .8rem 1rem;
-  border-radius: 8px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  box-shadow: 0 8px 24px rgba(0,0,0,.12);
-  color: var(--vp-c-text-1, #374151);
-  font-size: .825rem;
-  line-height: 1.5;
-  z-index: 1000;
-  transition: opacity .2s ease, transform .2s ease;
-  transform: translateX(-50%) translateY(-4px);
-  word-wrap: break-word;
-  hyphens: auto;
 }
 
-.info-tip-pop::before {
-  content: '';
-  position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 12px;
-  height: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  border-bottom: none;
-  border-right: none;
-  transform: translateX(-50%) rotate(45deg);
-}
-
-.info-tip:hover .info-tip-pop,
-.info-tip:focus .info-tip-pop {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
-
-.info-tip:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:last-child .info-tip-pop {
-  left: auto;
-  right: 0;
-  transform: translateX(0);
-}
-
-.info-tip:nth-last-child(-n+2) .info-tip-pop::before,
-.info-tip:last-child .info-tip-pop::before {
-  left: auto;
-  right: 1rem;
-  transform: translateX(0) rotate(45deg);
-}
-
-.info-tip:hover:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:focus:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:hover:last-child .info-tip-pop,
-.info-tip:focus:last-child .info-tip-pop {
-  transform: translateX(0) translateY(0);
-}
-
-.dkim-table-section {
-  margin-left: -1.5rem;
-  margin-right: -1.5rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-}
-
-.dkim-table-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  font-size: 1.25rem;
+.search-btn {
+  padding: 0.75rem 1.5rem;
+  background: var(--vp-c-brand);
+  color: #fff;
+  font-size: 0.9rem;
   font-weight: 600;
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, transform 0.1s, box-shadow 0.15s, padding 0.2s;
+  box-shadow: 0 1px 4px hsla(197, 87%, 50%, 0.3);
+  min-width: 130px;
 }
 
-.table-container {
-  overflow-x: auto;
-  margin: 1rem 0;
-  padding: 0 1rem;
-  background: var(--vp-c-bg, #ffffff);
+.has-result .search-btn { padding: 0.5rem 1.25rem; min-width: 100px; font-size: 0.825rem; }
+.search-btn:hover:not(:disabled) { background: var(--vp-c-brand-dark); transform: translateY(-1px); box-shadow: 0 4px 12px hsla(197, 87%, 50%, 0.35); }
+.search-btn:active:not(:disabled) { transform: translateY(0); }
+.search-btn:disabled { opacity: 0.55; cursor: not-allowed; box-shadow: none; }
+
+.btn-loading { display: flex; align-items: center; justify-content: center; }
+
+.spinner {
+  display: inline-block;
+  width: 14px; height: 14px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
 }
 
-.dkim-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 0;
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.form-hint {
+  margin: 0.625rem 0 0;
+  font-size: 0.75rem;
+  color: var(--vp-c-text-3, #9ca3af);
+}
+
+.form-hint code {
+  background: var(--vp-c-bg-mute, #f1f5f9);
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.7rem;
+}
+
+.form-hint-notice {
+  color: #b45309;
+}
+
+.dark .form-hint-notice {
+  color: #fbbf24;
+}
+
+/* Error */
+.error-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid rgba(220,38,38,0.2);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+}
+
+/* Results */
+.results { display: flex; flex-direction: column; gap: 0.875rem; }
+
+/* Hero */
+.hero {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  flex-wrap: wrap;
+}
+
+.hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.06) 0%, hsla(197,87%,50%,0.04) 100%); border-color: rgba(22,163,74,0.2); }
+.hero-fail { background: rgba(220,38,38,0.04); border-color: rgba(220,38,38,0.18); }
+
+.hero-icon { width: 52px; height: 52px; border-radius: 13px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.icon-pass { background: rgba(22,163,74,0.12); color: #16a34a; border: 1px solid rgba(22,163,74,0.2); }
+.icon-fail { background: rgba(220,38,38,0.1);  color: #dc2626; border: 1px solid rgba(220,38,38,0.15); }
+
+.hero-text { flex: 1; min-width: 0; }
+.hero-title { margin: 0 0 0.2rem; font-size: 1.25rem; font-weight: 700; color: var(--vp-c-text-1, #111827); }
+.hero-domain { margin: 0; font-size: 0.8rem; font-family: monospace; color: var(--vp-c-text-2, #6b7280); word-break: break-all; }
+
+.hero-score { display: flex; flex-direction: column; align-items: center; flex-shrink: 0; }
+.score-num { font-size: 1.6rem; font-weight: 800; color: var(--vp-c-text-1, #111827); line-height: 1; }
+.score-denom { font-size: 0.9rem; font-weight: 500; color: var(--vp-c-text-3, #9ca3af); }
+.score-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; padding: 0.15rem 0.5rem; border-radius: 999px; margin-top: 0.25rem; }
+
+.score-strong, .score-excellent { background: rgba(22,163,74,0.12); color: #15803d; }
+.score-good, .score-medium      { background: rgba(217,119,6,0.12);  color: #b45309; }
+.score-poor, .score-weak        { background: rgba(220,38,38,0.1);   color: #dc2626; }
+
+/* Signals grid */
+.signals-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.625rem; }
+
+.signal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.75rem 0.875rem;
+  border-radius: 10px;
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
   background: var(--vp-c-bg, #fff);
-  border-radius: 8px;
-  border: 1px solid var(--vp-c-border-soft, #ddd);
 }
 
-.dkim-table th,
-.dkim-table td {
+.signal-icon { display: inline-flex; align-items: center; }
+.signal-name { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--vp-c-text-2, #6b7280); }
+.signal-value { font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-1, #111827); }
+
+.signal-strong .signal-icon { color: #16a34a; }
+.signal-medium .signal-icon { color: #d97706; }
+.signal-weak   .signal-icon { color: #dc2626; }
+.signal-muted  .signal-icon { color: var(--vp-c-text-3, #9ca3af); }
+.signal-strong { border-color: rgba(22,163,74,0.25); }
+.signal-medium { border-color: rgba(217,119,6,0.25); }
+.signal-weak   { border-color: rgba(220,38,38,0.2); }
+
+/* Alerts */
+.alert { display: flex; gap: 0.75rem; padding: 0.875rem 1.125rem; border-radius: 10px; border: 1px solid transparent; font-size: 0.875rem; line-height: 1.6; }
+.alert > svg { flex-shrink: 0; margin-top: 0.1rem; }
+.alert ul { margin: 0; padding-left: 1.1rem; }
+.alert li + li { margin-top: 0.2rem; }
+.alert-warn { background: rgba(217,119,6,0.06); border-color: rgba(217,119,6,0.2); color: var(--vp-c-text-1); }
+.alert-warn > svg { color: #d97706; }
+.alert-tip { background: hsla(197,87%,50%,0.05); border-color: hsla(197,87%,50%,0.2); color: var(--vp-c-text-1); }
+.alert-tip > svg { color: var(--vp-c-brand-dark, #0891b2); }
+
+/* Disclosures */
+.disclosures { display: flex; flex-direction: column; gap: 0.5rem; }
+
+.disclosure {
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.disclosure-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 0.875rem 1.25rem;
-  text-align: left;
-  vertical-align: top;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
 }
 
-.dkim-table th {
-  background: var(--vp-c-bg-soft, #f5f5f5);
-  font-weight: 600;
-  border-bottom: 2px solid var(--vp-c-border, #e5e7eb);
+.disclosure-trigger::-webkit-details-marker { display: none; }
+.disclosure-trigger:hover { background: var(--vp-c-bg-soft, #f8f9fa); }
+.disclosure-label { font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-1, #374151); }
+.disclosure-chevron { color: var(--vp-c-text-3, #9ca3af); transition: transform 0.2s; }
+details[open] .disclosure-chevron { transform: rotate(180deg); }
+.disclosure-body { padding: 0 1.25rem 1.25rem; border-top: 1px solid var(--vp-c-border-soft, #f1f5f9); }
+
+.raw-record {
+  display: block;
+  margin-top: 0.875rem;
+  padding: 0.875rem 1rem;
+  background: var(--vp-c-bg-soft, #f8f9fa);
+  border-radius: 8px;
+  font-size: 0.8rem;
+  word-break: break-all;
+  color: var(--vp-c-text-1, #374151);
 }
 
-.tag-col { width: 15%; min-width: 80px; }
-.value-col { width: 50%; min-width: 200px; }
-.desc-col { width: 35%; min-width: 150px; }
+.tag-list { display: flex; flex-direction: column; margin-top: 0.875rem; }
 
-.tag-cell { 
-  font-family: monospace; 
-  font-weight: 600;
+.tag-row {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--vp-c-border-soft, #f1f5f9);
+}
+
+.tag-row:last-child { border-bottom: none; padding-bottom: 0; }
+.tag-row:first-child { padding-top: 0; }
+
+.tag-key {
+  flex-shrink: 0;
+  width: 1.5rem;
+  font-family: monospace;
+  font-weight: 700;
+  font-size: 0.825rem;
   color: var(--vp-c-brand);
 }
 
-.value-cell { 
-  font-family: monospace; 
+.tag-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 0.2rem; }
+
+.tag-value-line { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+
+.tag-value {
+  font-family: monospace;
+  font-size: 0.825rem;
+  color: var(--vp-c-text-1);
   word-break: break-all;
-  font-size: 0.875rem;
-  line-height: 1.4;
 }
 
-.desc-cell {
-  font-size: 0.875rem;
+.tag-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-shrink: 0;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--vp-c-bg-mute, #f1f5f9);
   color: var(--vp-c-text-2, #6b7280);
-  line-height: 1.4;
-}
-
-/* Result Sections */
-.section {
-  margin-top: 1.5rem;
-  padding: 1.25rem;
-  border-radius: 8px;
-}
-
-.section h4 {
-  margin: 0 0 1rem 0;
-  font-size: 1.25rem;
+  font-size: 0.7rem;
   font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
-.section ul {
-  margin: 0;
-  padding-left: 1.5rem;
-}
+.tag-copy-btn:hover { background: var(--vp-c-bg-soft, #e5e7eb); color: var(--vp-c-text-1); }
+.tag-copy-btn.copied { color: #16a34a; border-color: rgba(22,163,74,0.3); background: rgba(22,163,74,0.08); }
 
-.section li {
-  margin: 0.5rem 0;
-  line-height: 1.5;
-}
+.tag-desc { margin: 0; font-size: 0.8rem; color: var(--vp-c-text-2, #6b7280); }
 
-.warnings-section {
-  background: var(--vp-warning-soft, #fffbf0);
-  border: 1px solid rgba(214, 158, 46, 0.2);
-}
-
-.warnings-section h4 {
-  color: var(--vp-c-warning-1, #d69e2e);
-}
-
-.recommendations-section {
-  background: var(--vp-tip-soft, #f0f9ff);
-  border: 1px solid rgba(23, 162, 184, 0.18);
-}
-
-.recommendations-section h4 {
-  color: var(--vp-c-tip-1, #17a2b8);
-}
-
-/* Dark Mode */
-@media (prefers-color-scheme: dark) {
-  .refresh-captcha-btn {
-    background: var(--vp-c-bg-soft);
-    border-color: var(--vp-c-border);
-    color: var(--vp-c-text-1);
-  }
-  
-  .refresh-captcha-btn:hover:not(:disabled) {
-    border-color: var(--vp-c-brand);
-  }
-  
-  .dkim-table th {
-    background: var(--vp-c-bg-soft, #252736);
-    color: var(--vp-c-text-1, #aad0f7);
-  }
-  
-  .dkim-record {
-    background: var(--vp-c-bg-soft, #252736);
-    color: var(--vp-c-brand-light);
-  }
-  
-  .recommendations-section,
-  .recommendations-section ul,
-  .recommendations-section li {
-    color: #2d3748 !important;
-  }
-  
-  .info-tip-pop {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-    box-shadow: 0 8px 24px rgba(0,0,0,.3);
-  }
-  
-  .info-tip-pop::before {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-  }
-}
-
-@media (max-width: 480px) {
-  .info-tip-pop {
-    position: fixed;
-    left: 10px !important;
-    right: 10px !important;
-    top: auto !important;
-    bottom: 20px;
-    transform: none !important;
-    width: auto !important;
-    max-width: none !important;
-    z-index: 9999;
-  }
-  
-  .info-tip-pop::before {
-    display: none;
-  }
-  
-  .info-tip:hover .info-tip-pop,
-  .info-tip:focus .info-tip-pop {
-    transform: none !important;
-  }
-}
+/* Dark mode */
+.dark .hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.09) 0%, hsla(197,87%,50%,0.06) 100%); border-color: rgba(22,163,74,0.25); }
+.dark .hero-fail { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.22); }
+.dark .icon-pass { background: rgba(22,163,74,0.18); color: #4ade80; }
+.dark .icon-fail { background: rgba(220,38,38,0.18); color: #f87171; }
+.dark .score-strong, .dark .score-excellent { background: rgba(22,163,74,0.2); color: #4ade80; }
+.dark .score-good, .dark .score-medium      { background: rgba(217,119,6,0.2);  color: #fbbf24; }
+.dark .score-poor, .dark .score-weak        { background: rgba(220,38,38,0.2);  color: #f87171; }
+.dark .signal-strong .signal-icon { color: #4ade80; }
+.dark .signal-medium .signal-icon { color: #fbbf24; }
+.dark .signal-weak   .signal-icon { color: #f87171; }
+.dark .alert-warn { background: rgba(217,119,6,0.1); border-color: rgba(217,119,6,0.25); }
+.dark .alert-tip  { background: hsla(197,87%,50%,0.08); border-color: hsla(197,87%,50%,0.25); }
+.dark .alert-tip > svg { color: var(--vp-c-brand-light); }
+.dark .tag-copy-btn.copied { color: #4ade80; border-color: rgba(74,222,128,0.3); background: rgba(74,222,128,0.1); }
 
 /* Responsive */
-@media (max-width: 768px) {
-  .dkim-checker {
-    padding: 0 0.5rem;
-  }
-  
-  .tool-form,
-  .result-section {
-    padding: 1rem;
-    margin: 1rem 0;
-  }
-  
-  .dkim-table-section {
-    margin-left: -1rem;
-    margin-right: -1rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-  
-  .table-container {
-    margin: 1rem -1rem;
-  }
-  
-  .captcha-container {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  
-  .refresh-captcha-btn {
-    align-self: center;
-  }
-  
-  .dkim-table {
-    font-size: 0.875rem;
-    min-width: 600px;
-  }
-  
-  .dkim-table th,
-  .dkim-table td {
-    padding: 0.5rem 0.75rem;
-  }
-  
-  .dkim-record {
-    margin-right: 1rem;
-  }
+@media (max-width: 640px) {
+  .search-form { flex-direction: column; align-items: stretch; }
+  .search-btn { width: 100%; }
+  .hero { padding: 1.25rem; gap: 1rem; }
+  .hero-score { align-self: flex-start; }
+  .signals-grid { grid-template-columns: repeat(3, 1fr); gap: 0.5rem; }
+  .signal { padding: 0.625rem; }
 }
 
-@media (hover: none) and (pointer: coarse) {
-  .info-tip {
-    width: 1.25rem;
-    height: 1.25rem;
-    line-height: 1.25rem;
-  }
-  
-  .info-tip-pop {
-    padding: 1rem 1.25rem;
-    font-size: .875rem;
-  }
+@media (max-width: 400px) {
+  .signals-grid { grid-template-columns: 1fr; }
 }
 </style>

--- a/.vitepress/theme/free-tools/DkimChecker.vue
+++ b/.vitepress/theme/free-tools/DkimChecker.vue
@@ -204,19 +204,21 @@ onMounted(async () => {
             spellcheck="false"
           />
         </div>
-        <Turnstile
-          ref="turnstileRef"
-          class="turnstile-inline"
-          :class="{ 'turnstile-collapsed': result }"
-          @verified="onTurnstileVerified"
-          @expired="onTurnstileInvalid"
-          @error="onTurnstileInvalid"
-        />
         <button type="submit" class="search-btn" :disabled="isFormDisabled">
           <span v-if="loading" class="btn-loading"><span class="spinner"></span></span>
           <span v-else>Check DKIM</span>
         </button>
       </form>
+
+      <Turnstile
+        ref="turnstileRef"
+        class="turnstile-row"
+        :class="{ 'turnstile-collapsed': result }"
+        @verified="onTurnstileVerified"
+        @expired="onTurnstileInvalid"
+        @error="onTurnstileInvalid"
+      />
+
       <p v-if="guessedSelector" class="form-hint form-hint-notice">
         Guessed selector <code>google</code> from the switcher. Not right? Change it in the <strong>selector</strong> field above.
       </p>
@@ -439,14 +441,16 @@ onMounted(async () => {
 
 .selector-input-wrap input:focus { outline: none; box-shadow: none; }
 
-.turnstile-inline {
-  flex-shrink: 0;
-  transition: opacity 0.2s, max-width 0.2s, max-height 0.2s, margin 0.2s;
+.turnstile-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.75rem;
+  transition: opacity 0.2s, max-height 0.2s, margin 0.2s;
   overflow: hidden;
 }
 
-.turnstile-inline.turnstile-collapsed {
-  opacity: 0; max-width: 0; max-height: 0;
+.turnstile-row.turnstile-collapsed {
+  opacity: 0; max-height: 0; margin-top: 0;
   pointer-events: none;
   position: absolute;
 }

--- a/.vitepress/theme/free-tools/DkimChecker.vue
+++ b/.vitepress/theme/free-tools/DkimChecker.vue
@@ -119,8 +119,8 @@ function validateInputs() {
 }
 
 async function checkDkimHandler() {
-  result.value       = null
-  loading.value       = true
+  result.value = null
+  loading.value = true
   errorMessage.value = ''
 
   try {

--- a/.vitepress/theme/free-tools/DkimChecker.vue
+++ b/.vitepress/theme/free-tools/DkimChecker.vue
@@ -34,7 +34,9 @@ const isFormDisabled = computed(() => loading.value)
 const TRUNCATE_AT = 40
 
 function truncateMiddle(value) {
-  if (value.length <= TRUNCATE_AT) return value
+  if (value.length <= TRUNCATE_AT) {
+    return value
+  }
   const head = value.slice(0, 20)
   const tail = value.slice(-16)
   return `${head}…${tail}`
@@ -65,7 +67,11 @@ async function copyTagValue(tag) {
   try {
     await navigator.clipboard.writeText(tag.value)
     copiedTag.value = tag.tag
-    setTimeout(() => { if (copiedTag.value === tag.tag) copiedTag.value = '' }, 1500)
+    setTimeout(() => {
+      if (copiedTag.value === tag.tag) {
+        copiedTag.value = ''
+      }
+    }, 1500)
   } catch {
     /* clipboard unavailable */
   }
@@ -78,15 +84,26 @@ const keyTypeSignal = computed(() => {
 
 const keyLengthSignal = computed(() => {
   const p = dkimTags.value.find(t => t.tag === 'p')?.value
-  if (!p) return null
+  if (!p) {
+    return null
+  }
   const approxBits = Math.floor((p.length * 6) / 8) * 8
-  if (approxBits >= 2048) return { label: `~${approxBits} bit`, level: 'strong', icon: 'check' }
-  if (approxBits >= 1024) return { label: `~${approxBits} bit`, level: 'medium', icon: 'minus' }
+  if (approxBits >= 2048) {
+    return { label: `~${approxBits} bit`, level: 'strong', icon: 'check' }
+  }
+  if (approxBits >= 1024) {
+    return { label: `~${approxBits} bit`, level: 'medium', icon: 'minus' }
+  }
   return { label: `~${approxBits} bit`, level: 'weak', icon: 'alert' }
 })
 
-function onTurnstileVerified(token) { turnstileToken.value = token }
-function onTurnstileInvalid()       { turnstileToken.value = '' }
+function onTurnstileVerified(token) {
+  turnstileToken.value = token
+}
+
+function onTurnstileInvalid() {
+  turnstileToken.value = ''
+}
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -107,7 +124,10 @@ async function checkDkimHandler() {
   errorMessage.value = ''
 
   try {
-    if (!validateInputs()) { loading.value = false; return }
+    if (!validateInputs()) {
+      loading.value = false
+      return
+    }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
@@ -133,7 +153,9 @@ async function checkDkimHandler() {
     resetTurnstile()
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) resetTurnstile()
+    if (err.status === 401) {
+      resetTurnstile()
+    }
   } finally {
     loading.value = false
   }
@@ -145,11 +167,15 @@ onMounted(async () => {
   const urlParams = new URLSearchParams(window.location.search)
 
   loadFromUrl({ domain, selector })
-  if (!selector.value) selector.value = DEFAULT_SELECTOR
+  if (!selector.value) {
+    selector.value = DEFAULT_SELECTOR
+  }
   await nextTick()
 
   if (urlParams.get('run') === '1' && domain.value) {
-    if (urlParams.get('selector') === 'google') guessedSelector.value = true
+    if (urlParams.get('selector') === 'google') {
+      guessedSelector.value = true
+    }
     await turnstileRef.value?.whenReady()
     await checkDkimHandler()
     await nextTick()

--- a/.vitepress/theme/free-tools/DkimChecker.vue
+++ b/.vitepress/theme/free-tools/DkimChecker.vue
@@ -189,7 +189,7 @@ onMounted(async () => {
 
     <ToolSwitcher :domain="domain" />
 
-    <!-- ── Inline form ── -->
+    <!-- Inline form -->
     <div class="search-bar" :class="{ 'has-result': result }">
       <form class="search-form" @submit.prevent="checkDkimHandler">
         <div class="search-input-wrap">
@@ -251,13 +251,13 @@ onMounted(async () => {
       <p v-else class="form-hint">Common selectors: <code>default</code>, <code>google</code>, <code>selector1</code>, <code>mail</code></p>
     </div>
 
-    <!-- ── Error ── -->
+    <!-- Error -->
     <div v-if="errorMessage" class="error-pill">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
       {{ errorMessage }}
     </div>
 
-    <!-- ── Results ── -->
+    <!-- Results -->
     <div v-if="result" class="results" ref="resultsRef">
 
       <!-- Hero -->

--- a/.vitepress/theme/free-tools/DkimChecker.vue
+++ b/.vitepress/theme/free-tools/DkimChecker.vue
@@ -18,13 +18,13 @@ const DKIM_TAG_DESCRIPTIONS = {
   n: 'Free-form notes.',
 }
 
-const domain       = ref('')
-const selector     = ref('')
-const loading      = ref(false)
-const result       = ref(null)
+const domain = ref('')
+const selector = ref('')
+const loading = ref(false)
+const result = ref(null)
 const errorMessage = ref('')
 
-const turnstileRef   = ref(null)
+const turnstileRef = ref(null)
 const turnstileToken = ref('')
 const guessedSelector = ref(false)
 const resultsRef = ref(null)
@@ -140,10 +140,10 @@ async function checkDkimHandler() {
     })
 
     result.value = {
-      valid:    true,
-      domain:   data.result.domain || domain.value,
+      valid: true,
+      domain: data.result.domain || domain.value,
       selector: data.result.selector || selector.value,
-      record:    data.result.rawRecord || data.result.record,
+      record: data.result.rawRecord || data.result.record,
       rawRecord: data.result.rawRecord || data.result.record,
       warnings: data.result.warnings || [],
       recommendations: data.result.recommendations || [],

--- a/.vitepress/theme/free-tools/DmarcChecker.vue
+++ b/.vitepress/theme/free-tools/DmarcChecker.vue
@@ -4,90 +4,112 @@ import { checkDmarc } from '../../../connectors/bluefoxEmailToolsApi.js'
 import { isSessionValid } from '../../../connectors/turnstileSession.js'
 import { syncWithUrl, loadFromUrl } from './helpers/urlSync.js'
 import Turnstile from './Turnstile.vue'
+import SignalIcon from './SignalIcon.vue'
+import ToolSwitcher from './ToolSwitcher.vue'
 
-// ---- VARIABLES ----
 const DMARC_TAG_DESCRIPTIONS = {
-  v: "DMARC version tag (should be DMARC1).",
-  p: "Policy for main domain (none/quarantine/reject).",
-  sp: "Subdomain policy (if present).",
-  np: "Policy for non-existent subdomains.",
-  rua: "Aggregate report recipient(s).",
-  ruf: "Forensic report recipient(s).",
-  adkim: "DKIM alignment mode (r=relaxed, s=strict).",
-  aspf: "SPF alignment mode (r=relaxed, s=strict).",
-  pct: "Percent of mail subject to filtering.",
-  fo: "Failure reporting options.",
-  ri: "Report interval in seconds.",
-  t: "Test mode flag (y = testing, policy not enforced).",
-  psd: "Public suffix domain flag.",
-  rf: "Report format (deprecated)."
+  v:     'DMARC version tag (should be DMARC1).',
+  p:     'Policy for main domain (none/quarantine/reject).',
+  sp:    'Subdomain policy (if present).',
+  np:    'Policy for non-existent subdomains.',
+  rua:   'Aggregate report recipient(s).',
+  ruf:   'Forensic report recipient(s).',
+  adkim: 'DKIM alignment mode (r=relaxed, s=strict).',
+  aspf:  'SPF alignment mode (r=relaxed, s=strict).',
+  pct:   'Percent of mail subject to filtering.',
+  fo:    'Failure reporting options.',
+  ri:    'Report interval in seconds.',
+  t:     'Test mode flag (y = testing, policy not enforced).',
+  psd:   'Public suffix domain flag.',
+  rf:    'Report format (deprecated).',
 }
 
-const domain = ref('')
-const loading = ref(false)
-const result = ref(null)
-const errorMessage = ref('')
+const domain        = ref('')
+const loading       = ref(false)
+const result        = ref(null)
+const errorMessage  = ref('')
+const showRawRecord = ref(false)
+const showTagTable  = ref(false)
 
-// Turnstile state
-const turnstileRef = ref(null)
+const turnstileRef   = ref(null)
 const turnstileToken = ref('')
+const resultsRef = ref(null)
 
-const isFormDisabled = computed(() =>
-  loading.value
-)
+const isFormDisabled = computed(() => loading.value)
 
 const dmarcTags = computed(() => {
-  const parsed = result.value?.parsed || {}
+  const parsed       = result.value?.parsed       || {}
   const explanations = result.value?.explanations || {}
   return Object.entries(DMARC_TAG_DESCRIPTIONS)
     .map(([tag, description]) => ({
-      tag: tag.toUpperCase(),
-      value: parsed[tag] || '',
-      description: explanations[tag] || description
+      tag:         tag.toUpperCase(),
+      value:       parsed[tag] || '',
+      description: explanations[tag] || description,
     }))
     .filter(item => item.value)
 })
 
-const testModeWarning = computed(() =>
-  result.value?.warnings?.find(w => /^t=y/i.test(w)) ?? null
+const policySignal = computed(() => {
+  const p = result.value?.parsed?.p?.toLowerCase()
+  if (p === 'reject')      return { label: 'Reject',      level: 'strong',  icon: 'check' }
+  if (p === 'quarantine')  return { label: 'Quarantine',  level: 'medium',  icon: 'minus' }
+  if (p === 'none')        return { label: 'None',        level: 'weak',    icon: 'alert' }
+  return null
+})
+
+const pctSignal = computed(() => {
+  const pct = result.value?.parsed?.pct
+  if (!pct) return { label: '100% (default)', level: 'strong', icon: 'check' }
+  const n = parseInt(pct, 10)
+  if (n === 100) return { label: '100%',      level: 'strong', icon: 'check' }
+  if (n >= 50)   return { label: `${n}%`,     level: 'medium', icon: 'minus' }
+  return         { label: `${n}%`,            level: 'weak',   icon: 'alert' }
+})
+
+const dkimAlignSignal = computed(() => {
+  const adkim = result.value?.parsed?.adkim?.toLowerCase()
+  if (adkim === 's') return { label: 'DKIM Strict',  level: 'strong', icon: 'check' }
+  return               { label: 'DKIM Relaxed', level: 'medium', icon: 'minus' }
+})
+
+const spfAlignSignal = computed(() => {
+  const aspf = result.value?.parsed?.aspf?.toLowerCase()
+  if (aspf === 's') return { label: 'SPF Strict',  level: 'strong', icon: 'check' }
+  return              { label: 'SPF Relaxed', level: 'medium', icon: 'minus' }
+})
+
+const ruaSignal = computed(() => {
+  const rua = result.value?.parsed?.rua
+  if (rua) return { label: 'Reports On',  level: 'strong', icon: 'check' }
+  return    { label: 'No Reports',   level: 'weak',   icon: 'alert' }
+})
+
+const rufSignal = computed(() => {
+  const ruf = result.value?.parsed?.ruf
+  if (ruf) return { label: 'Forensics On', level: 'medium', icon: 'minus' }
+  return    { label: 'No Forensics', level: 'muted',  icon: 'dot' }
+})
+
+const criticalWarnings = computed(() =>
+  result.value?.warnings?.filter(w =>
+    !/^t=y/i.test(w) && !/deprecated/i.test(w)
+  ) ?? []
 )
 
 const deprecatedWarnings = computed(() =>
   result.value?.warnings?.filter(w => /deprecated/i.test(w)) ?? []
 )
 
-const regularWarnings = computed(() =>
-  result.value?.warnings?.filter(w =>
-    !/^t=y/i.test(w) && !/deprecated/i.test(w)
-  ) ?? []
+const testModeWarning = computed(() =>
+  result.value?.warnings?.find(w => /^t=y/i.test(w)) ?? null
 )
 
-const npRecommendations = computed(() =>
-  result.value?.recommendations?.filter(r => /\bnp=/i.test(r)) ?? []
+const recommendations = computed(() =>
+  result.value?.recommendations ?? []
 )
 
-const rfc9989Ready = computed(() => {
-  const protocol = result.value?.protocol
-  if (!protocol) {
-    return false
-  }
-  return !protocol.deprecatedTags?.length &&
-    !protocol.unknownTags?.length &&
-    !protocol.testMode
-})
-
-const regularRecommendations = computed(() =>
-  result.value?.recommendations?.filter(r => !/\bnp=/i.test(r)) ?? []
-)
-
-// ---- FUNCTIONS ----
-function onTurnstileVerified(token) {
-  turnstileToken.value = token
-}
-
-function onTurnstileInvalid() {
-  turnstileToken.value = ''
-}
+function onTurnstileVerified(token)  { turnstileToken.value = token }
+function onTurnstileInvalid()        { turnstileToken.value = '' }
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -99,919 +121,857 @@ function validateInputs() {
     errorMessage.value = 'Please enter a domain name'
     return false
   }
-
   return true
 }
 
 async function checkDmarcHandler() {
-  result.value = null
-  loading.value = true
+  result.value      = null
+  loading.value     = true
   errorMessage.value = ''
+  showRawRecord.value = false
+  showTagTable.value  = false
 
   try {
-    if (!validateInputs()) {
-      loading.value = false
-      return
-    }
+    if (!validateInputs()) { loading.value = false; return }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
     }
 
     const data = await checkDmarc({
-      domain: domain.value,
-      turnstileToken: turnstileToken.value
+      domain:         domain.value,
+      turnstileToken: turnstileToken.value,
     })
 
     result.value = {
-      valid: true,
-      domain: data.result.domain || domain.value,
-      record: data.result.rawRecord || data.result.record || 'Not found',
-      parsed: data.result.parsed || {},
+      valid:        true,
+      domain:       data.result.domain       || domain.value,
+      record:       data.result.rawRecord    || data.result.record || 'Not found',
+      parsed:       data.result.parsed       || {},
       explanations: data.result.explanations || {},
       checkedRecord: data.result.checkedRecord,
-      score: data.result.score,
-      protocol: data.result.protocol || null,
-      warnings: data.result.warnings || [],
-      recommendations: data.result.recommendations || []
+      score:        data.result.score,
+      protocol:     data.result.protocol     || null,
+      warnings:     data.result.warnings     || [],
+      recommendations: data.result.recommendations || [],
     }
 
     resetTurnstile()
-
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) {
-      resetTurnstile()
-    }
+    if (err.status === 401) resetTurnstile()
   } finally {
     loading.value = false
   }
 }
 
-// ---- WATCHES ----
-watch(domain, () => {
-  syncWithUrl({ domain: domain.value })
-})
+watch(domain, () => syncWithUrl({ domain: domain.value }))
 
-// ---- LIFECYCLE ----
 onMounted(async () => {
-  loadFromUrl({ domain })
+  const urlParams = new URLSearchParams(window.location.search)
 
+  loadFromUrl({ domain })
   await nextTick()
+
+  if (urlParams.get('run') === '1' && domain.value) {
+    await turnstileRef.value?.whenReady()
+    await checkDmarcHandler()
+    await nextTick()
+    resultsRef.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
 })
 </script>
 
 <template>
   <div class="dmarc-checker">
-    <div class="tool-form">
-      <form @submit.prevent="checkDmarcHandler">
-        <!-- Domain Input -->
-        <div class="form-group">
-          <label for="domain">Domain:</label>
+
+    <ToolSwitcher :domain="domain" />
+
+    <!-- ── Inline form ── -->
+    <div class="search-bar" :class="{ 'has-result': result }">
+      <form class="search-form" @submit.prevent="checkDmarcHandler">
+        <div class="search-input-wrap">
+          <span class="search-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+            </svg>
+          </span>
           <input
             id="domain"
             v-model="domain"
             type="text"
             placeholder="example.com"
             :disabled="loading"
+            autocomplete="off"
+            spellcheck="false"
             required
           />
+          <button
+            v-if="domain && !loading"
+            type="button"
+            class="search-clear"
+            aria-label="Clear domain"
+            @click="domain = ''"
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
         </div>
-
-        <!-- Verification -->
-        <div class="form-group">
-          <Turnstile
-            ref="turnstileRef"
-            @verified="onTurnstileVerified"
-            @expired="onTurnstileInvalid"
-            @error="onTurnstileInvalid"
-          />
-        </div>
-
-        <!-- Submit Button -->
-        <button type="submit" class="check-btn" :disabled="isFormDisabled">
+        <Turnstile
+          ref="turnstileRef"
+          class="turnstile-inline"
+          :class="{ 'turnstile-collapsed': result }"
+          @verified="onTurnstileVerified"
+          @expired="onTurnstileInvalid"
+          @error="onTurnstileInvalid"
+        />
+        <button type="submit" class="search-btn" :disabled="isFormDisabled">
           <span v-if="loading" class="btn-loading">
-            <div class="loading-spinner"></div>
-            Checking...
+            <span class="spinner"></span>
           </span>
           <span v-else>Check DMARC</span>
         </button>
       </form>
     </div>
 
-    <!-- Error Display -->
-    <div v-if="errorMessage" class="error-section">
-      <p class="error-message">{{ errorMessage }}</p>
+    <!-- ── Error ── -->
+    <div v-if="errorMessage" class="error-pill">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      {{ errorMessage }}
     </div>
 
-    <!-- Results -->
-    <div v-if="result" class="result-section">
-      <h3>DMARC Check Results</h3>
-      
-      <!-- Status -->
-      <div class="status-box">
-        <p><strong>{{ result.valid ? 'DMARC Record Found' : 'DMARC Record Missing or Invalid' }}</strong></p>
-        <p v-if="result.score">
-          <strong>Security Score:</strong>
-          {{ result.score.value }}/{{ result.score.outOf }} ({{ result.score.level }})
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Comprehensive score based on policy strength, alignment settings, and reporting configuration.</span>
-          </span>
-        </p>
-      </div>
+    <!-- ── Results ── -->
+    <div v-if="result" class="results" ref="resultsRef">
 
-      <!-- Basic Information -->
-      <div class="info-section">
-        <h4>
-          Basic Information
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Essential details about the DMARC record found for this domain.</span>
-          </span>
-        </h4>
-        <p><strong>Domain:</strong> {{ result.domain }}</p>
-        <p v-if="result.checkedRecord">
-          <strong>Checked Record:</strong> {{ result.checkedRecord }}
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">The DNS record location where DMARC policy was found (usually _dmarc.[domain]).</span>
-          </span>
-        </p>
-        <p>
-          <strong>DMARC Record:</strong> {{ result.record }}
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">The complete DMARC policy string retrieved from DNS.</span>
-          </span>
-        </p>
-      </div>
-
-      <!-- DMARC Tags Table -->
-      <div v-if="dmarcTags.length" class="dmarc-table-section">
-        <h4>
-          DMARC Record Breakdown
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Each tag in the DMARC record explained. These define the email authentication policy and reporting.</span>
-          </span>
-        </h4>
-        <div class="table-container">
-          <table class="dmarc-table">
-            <thead>
-              <tr>
-                <th class="tag-col">Tag</th>
-                <th class="value-col">Value</th>
-                <th class="desc-col">Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="tag in dmarcTags" :key="tag.tag">
-                <td class="tag-cell">{{ tag.tag }}</td>
-                <td class="value-cell">{{ tag.value }}</td>
-                <td class="desc-cell">{{ tag.description }}</td>
-              </tr>
-            </tbody>
-          </table>
+      <!-- Hero status -->
+      <div class="hero" :class="result.valid ? 'hero-pass' : 'hero-fail'">
+        <div class="hero-icon" :class="result.valid ? 'icon-pass' : 'icon-fail'">
+          <svg v-if="result.valid" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          <svg v-else width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </div>
+        <div class="hero-text">
+          <h2 class="hero-title">{{ result.valid ? 'DMARC Configured' : 'DMARC Missing' }}</h2>
+          <p class="hero-domain">{{ result.checkedRecord || ('_dmarc.' + result.domain) }}</p>
+        </div>
+        <div v-if="result.score" class="hero-score">
+          <span class="score-num">{{ result.score.value }}<span class="score-denom">/{{ result.score.outOf }}</span></span>
+          <span class="score-label" :class="'score-' + result.score.level?.toLowerCase()">{{ result.score.level }}</span>
         </div>
       </div>
 
-      <!-- Standards Compliance (RFC 9989) -->
-      <div v-if="result.protocol" class="protocol-section">
-        <h4>
-          Standards Compliance
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Checks your DMARC record against the updated DMARC standard (RFC 9989). Deprecated and unknown tags are ignored by receivers.</span>
-          </span>
-        </h4>
-        <div class="protocol-grid">
-          <div class="policy-item">
-            <span class="label">RFC 9989 Ready:</span>
-            <span class="value">
-              <span class="proto-badge" :class="rfc9989Ready ? 'pass' : 'warn'">
-                {{ rfc9989Ready ? 'Yes' : 'Needs attention' }}
-              </span>
-            </span>
-          </div>
-          <div v-if="result.protocol.deprecatedTags?.length" class="policy-item">
-            <span class="label">Deprecated Tags:</span>
-            <span class="value">
-              <span class="proto-badge warn">{{ result.protocol.deprecatedTags.join(', ') }}</span>
-            </span>
-          </div>
-          <div v-if="result.protocol.testMode" class="policy-item">
-            <span class="label">Test Mode:</span>
-            <span class="value"><span class="proto-badge warn">t=y (not enforced)</span></span>
-          </div>
-          <div v-if="result.protocol.unknownTags?.length" class="policy-item">
-            <span class="label">Unknown Tags:</span>
-            <span class="value">
-              <span class="proto-badge warn">{{ result.protocol.unknownTags.join(', ') }}</span>
-            </span>
-          </div>
-          <div class="policy-item">
-            <span class="label">Non-Existent Subdomain Policy (np=):</span>
-            <span class="value">
-              <span class="proto-badge" :class="result.protocol.npConfigured ? 'pass' : 'muted'">
-                {{ result.protocol.npConfigured ? 'Configured' : 'Not set' }}
-              </span>
-            </span>
-          </div>
+      <!-- Policy signals grid -->
+      <div v-if="result.valid" class="signals-grid">
+        <div class="signal" :class="'signal-' + policySignal?.level">
+          <span class="signal-icon"><SignalIcon :name="policySignal?.icon" /></span>
+          <span class="signal-name">Policy</span>
+          <span class="signal-value">{{ policySignal?.label }}</span>
+        </div>
+        <div class="signal" :class="'signal-' + pctSignal?.level">
+          <span class="signal-icon"><SignalIcon :name="pctSignal?.icon" /></span>
+          <span class="signal-name">Coverage</span>
+          <span class="signal-value">{{ pctSignal?.label }}</span>
+        </div>
+        <div class="signal" :class="'signal-' + dkimAlignSignal?.level">
+          <span class="signal-icon"><SignalIcon :name="dkimAlignSignal?.icon" /></span>
+          <span class="signal-name">DKIM Align</span>
+          <span class="signal-value">{{ dkimAlignSignal?.label }}</span>
+        </div>
+        <div class="signal" :class="'signal-' + spfAlignSignal?.level">
+          <span class="signal-icon"><SignalIcon :name="spfAlignSignal?.icon" /></span>
+          <span class="signal-name">SPF Align</span>
+          <span class="signal-value">{{ spfAlignSignal?.label }}</span>
+        </div>
+        <div class="signal" :class="'signal-' + ruaSignal?.level">
+          <span class="signal-icon"><SignalIcon :name="ruaSignal?.icon" /></span>
+          <span class="signal-name">Aggregate</span>
+          <span class="signal-value">{{ ruaSignal?.label }}</span>
+        </div>
+        <div class="signal" :class="'signal-' + rufSignal?.level">
+          <span class="signal-icon"><SignalIcon :name="rufSignal?.icon" /></span>
+          <span class="signal-name">Forensic</span>
+          <span class="signal-value">{{ rufSignal?.label }}</span>
         </div>
       </div>
 
-      <!-- t=y staging warning (prominent, not a list item) -->
-      <div v-if="testModeWarning" class="test-mode-banner">
-        <strong>Test Mode Active</strong>
-        <p>{{ testModeWarning }}</p>
+      <!-- Test-mode banner -->
+      <div v-if="testModeWarning" class="alert alert-testmode">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <div>
+          <strong>Test mode active — policy not enforced</strong>
+          <p>{{ testModeWarning }}</p>
+        </div>
       </div>
 
-      <!-- Regular warnings -->
-      <div v-if="regularWarnings.length" class="section warnings-section">
-        <h4>Warnings</h4>
+      <!-- Critical warnings -->
+      <div v-if="criticalWarnings.length" class="alert alert-warn">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
         <ul>
-          <li v-for="warning in regularWarnings" :key="warning">{{ warning }}</li>
-        </ul>
-      </div>
-
-      <!-- Deprecated tag notices (muted, informational) -->
-      <div v-if="deprecatedWarnings.length" class="section deprecated-section">
-        <h4>Deprecated Tags</h4>
-        <ul>
-          <li v-for="warning in deprecatedWarnings" :key="warning">{{ warning }}</li>
+          <li v-for="w in criticalWarnings" :key="w">{{ w }}</li>
         </ul>
       </div>
 
       <!-- Recommendations -->
-      <div v-if="regularRecommendations.length" class="section recommendations-section">
-        <h4>Recommendations</h4>
+      <div v-if="recommendations.length" class="alert alert-tip">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
         <ul>
-          <li v-for="rec in regularRecommendations" :key="rec">{{ rec }}</li>
+          <li v-for="r in recommendations" :key="r">{{ r }}</li>
         </ul>
       </div>
 
-      <!-- Advanced (np= and similar) -->
-      <div v-if="npRecommendations.length" class="section advanced-section">
-        <h4>Advanced</h4>
+      <!-- Deprecated notices -->
+      <div v-if="deprecatedWarnings.length" class="alert alert-muted">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
         <ul>
-          <li v-for="rec in npRecommendations" :key="rec">{{ rec }}</li>
+          <li v-for="w in deprecatedWarnings" :key="w">{{ w }}</li>
         </ul>
       </div>
-    </div>
+
+      <!-- Expert details — collapsed by default -->
+      <div class="disclosures">
+        <details class="disclosure">
+          <summary class="disclosure-trigger" @click="showRawRecord = !showRawRecord">
+            <span class="disclosure-label">Raw record</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <code class="raw-record">{{ result.record }}</code>
+          </div>
+        </details>
+
+        <details v-if="dmarcTags.length" class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">Tag breakdown</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <table class="tag-table">
+              <thead>
+                <tr>
+                  <th>Tag</th>
+                  <th>Value</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="tag in dmarcTags" :key="tag.tag">
+                  <td class="td-tag">{{ tag.tag }}</td>
+                  <td class="td-value">{{ tag.value }}</td>
+                  <td class="td-desc">{{ tag.description }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </details>
+      </div>
+
+    </div><!-- /results -->
   </div>
 </template>
 
 <style scoped>
+/* ── Root ── */
 .dmarc-checker {
-  max-width: 800px;
+  max-width: 780px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 1rem 3rem;
+  font-family: inherit;
 }
 
-.tool-form {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 12px;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
+/* ── Search bar ── */
+.search-bar {
+  margin: 2rem 0 1.5rem;
+  transition: margin 0.2s;
 }
 
-.form-group {
-  margin-bottom: 1.5rem;
+.search-bar.has-result {
+  margin: 0 0 1rem;
 }
 
-.form-group label {
-  display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--vp-c-text-1, #374151);
-  font-size: 0.9rem;
-}
-
-.form-group input {
-  width: 100%;
-  padding: 0.875rem 1rem;
-  border: 2px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 8px;
-  font-size: 1rem;
-  transition: border-color 0.2s ease;
-  box-sizing: border-box;
-  background: var(--vp-c-bg, #ffffff);
-  color: var(--vp-c-text-1, #374151);
-}
-
-.form-group input:focus {
-  outline: none;
-  border-color: var(--vp-c-brand);
-  box-shadow: 0 0 0 3px rgba(19, 176, 238, 0.1);
-}
-
-.form-group input:disabled {
-  background: var(--vp-c-bg-mute, #f1f5f9);
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-/* CAPTCHA Styles */
-.captcha-expired-message {
-  background: #fff3cd;
-  border: 1px solid #ffc107;
-  color: #856404;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1rem;
-  font-size: 0.875rem;
-}
-
-.captcha-container {
+.search-form {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  transition: transform 0.2s;
 }
 
-.captcha-image-container {
+.search-input-wrap {
   flex: 1;
-  min-height: 50px;
+  min-width: 220px;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.875rem;
+  color: var(--vp-c-text-3, #9ca3af);
+  display: flex;
+  pointer-events: none;
+}
+
+.search-input-wrap input {
+  width: 100%;
+  padding: 0.75rem 2.25rem 0.75rem 2.5rem;
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
+  font-size: 1rem;
+  background: var(--vp-c-bg, #fff);
+  color: var(--vp-c-text-1, #111827);
+  transition: border-color 0.15s, box-shadow 0.15s, padding 0.2s;
+  box-sizing: border-box;
+}
+
+.has-result .search-input-wrap input {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.search-clear {
+  position: absolute;
+  right: 0.625rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #ffffff;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 6px;
-  padding: 0.5rem;
-}
-
-.captcha-loading,
-.captcha-placeholder {
-  color: #6b7280;
-  font-style: italic;
-  text-align: center;
-}
-
-.load-captcha-btn {
-  background: var(--vp-c-brand);
-  color: white;
+  width: 20px;
+  height: 20px;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
+  background: var(--vp-c-bg-mute, #f1f5f9);
+  color: var(--vp-c-text-2, #6b7280);
+  border-radius: 50%;
   cursor: pointer;
-  font-size: 0.875rem;
-  transition: background-color 0.2s ease;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
 }
 
-.load-captcha-btn:hover {
-  background: var(--vp-c-brand-light);
+.search-clear:hover {
+  background: var(--vp-c-bg-soft, #e5e7eb);
+  color: var(--vp-c-text-1, #111827);
 }
 
-.refresh-captcha-btn {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  padding: 0.5rem;
-  border-radius: 6px;
-  cursor: pointer;
-  width: 2.5rem;
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
-}
-
-.refresh-captcha-btn:hover:not(:disabled) {
-  background: var(--vp-c-bg, #ffffff);
+.search-input-wrap input:focus {
+  outline: none;
   border-color: var(--vp-c-brand);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
 }
 
-.refresh-captcha-btn:disabled {
+.search-input-wrap input:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.refresh-captcha-btn img {
-  width: 16px;
-  height: 16px;
+.turnstile-inline {
+  flex-shrink: 0;
+  transition: opacity 0.2s, max-width 0.2s, max-height 0.2s, margin 0.2s;
+  overflow: hidden;
 }
 
-.captcha-help {
-  display: block;
-  margin-top: 0.5rem;
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-style: italic;
+.turnstile-inline.turnstile-collapsed {
+  opacity: 0;
+  max-width: 0;
+  max-height: 0;
+  pointer-events: none;
+  position: absolute;
 }
 
-/* Button */
-.check-btn {
+.search-btn {
+  padding: 0.75rem 1.5rem;
   background: var(--vp-c-brand);
-  color: #ffffff;
-  padding: 0.875rem 2rem;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 1rem;
+  color: #fff;
+  font-size: 0.9rem;
   font-weight: 600;
-  transition: all 0.2s ease;
-  width: 100%;
-  box-shadow: 0 2px 4px rgba(19, 176, 238, 0.2);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, transform 0.1s, box-shadow 0.15s, padding 0.2s;
+  box-shadow: 0 1px 4px hsla(197, 87%, 50%, 0.3);
+  min-width: 130px;
 }
 
-.check-btn:hover:not(:disabled) {
-  background: var(--vp-c-brand-light);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(19, 176, 238, 0.25);
+.has-result .search-btn {
+  padding: 0.5rem 1.25rem;
+  min-width: 100px;
+  font-size: 0.825rem;
 }
 
-.check-btn:active:not(:disabled) {
+.search-btn:hover:not(:disabled) {
   background: var(--vp-c-brand-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px hsla(197, 87%, 50%, 0.35);
+}
+
+.search-btn:active:not(:disabled) {
   transform: translateY(0);
 }
 
-.check-btn:disabled {
-  background: var(--vp-c-bg-mute, #9ca3af);
+.search-btn:disabled {
+  opacity: 0.55;
   cursor: not-allowed;
-  transform: none;
   box-shadow: none;
 }
 
 .btn-loading {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
   justify-content: center;
 }
 
-.loading-spinner {
-  width: 12px;
-  height: 12px;
-  border: 1.5px solid rgba(255, 255, 255, 0.3);
-  border-top: 1.5px solid #ffffff;
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2.5px solid rgba(255,255,255,0.3);
+  border-top-color: #fff;
   border-radius: 50%;
-  animation: spin 1s linear infinite;
+  animation: spin 0.7s linear infinite;
 }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
+@keyframes spin { to { transform: rotate(360deg); } }
 
-/* Error Section */
-.error-section {
-  background: var(--vp-danger-soft, #f8d7da);
-  color: var(--vp-c-danger-1, #721c24);
-  padding: 1rem;
+/* ── Error ── */
+.error-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid rgba(220, 38, 38, 0.2);
   border-radius: 8px;
-  margin: 1rem 0;
-  border: 1px solid var(--vp-c-danger-2, #f5c6cb);
-}
-
-.error-message {
-  margin: 0;
+  font-size: 0.875rem;
   font-weight: 500;
-}
-
-/* Results Section */
-.result-section {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.result-section h3 {
-  margin: 0 0 1.5rem 0;
-  color: var(--vp-c-text-1, #1a202c);
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.status-box {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  padding: 1.25rem;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 8px;
   margin-bottom: 1.5rem;
 }
 
-.status-box p {
-  margin: 0.5rem 0;
-  font-size: 1rem;
+/* ── Results ── */
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
 }
 
-/* Info Section */
-.info-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
+/* ── Hero ── */
+.hero {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
 }
 
-.info-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
+.hero-pass {
+  background: linear-gradient(135deg, rgba(22,163,74,0.06) 0%, rgba(19,176,238,0.04) 100%);
+  border-color: rgba(22, 163, 74, 0.2);
 }
 
-.info-section p {
-  margin: 0.75rem 0;
-  color: var(--vp-c-text-2, #4a5568);
-  line-height: 1.6;
+.hero-fail {
+  background: rgba(220, 38, 38, 0.04);
+  border-color: rgba(220, 38, 38, 0.18);
 }
 
-/* Info tip styles */
-.info-tip {
-  display: inline-block;
-  margin-left: .3rem;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1rem;
-  text-align: center;
-  border-radius: 50%;
-  background: var(--vp-c-brand);
-  color: #fff;
-  font-size: .675rem;
-  cursor: help;
-  position: relative;
-  vertical-align: middle;
+.hero-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
-.info-tip-pop {
-  opacity: 0;
-  pointer-events: none;
-  position: absolute;
-  left: 50%;
-  top: calc(100% + 8px);
-  transform: translateX(-50%);
-  width: max-content;
-  max-width: min(300px, 90vw);
-  padding: .8rem 1rem;
-  border-radius: 8px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  box-shadow: 0 8px 24px rgba(0,0,0,.12);
-  color: var(--vp-c-text-1, #374151);
-  font-size: .825rem;
-  line-height: 1.5;
-  z-index: 1000;
-  transition: opacity .2s ease, transform .2s ease;
-  transform: translateX(-50%) translateY(-4px);
-  word-wrap: break-word;
-  hyphens: auto;
+.icon-pass {
+  background: rgba(22, 163, 74, 0.12);
+  color: #16a34a;
+  border: 1px solid rgba(22, 163, 74, 0.2);
 }
 
-.info-tip-pop::before {
-  content: '';
-  position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 12px;
-  height: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  border-bottom: none;
-  border-right: none;
-  transform: translateX(-50%) rotate(45deg);
+.icon-fail {
+  background: rgba(220, 38, 38, 0.1);
+  color: #dc2626;
+  border: 1px solid rgba(220, 38, 38, 0.15);
 }
 
-.info-tip:hover .info-tip-pop,
-.info-tip:focus .info-tip-pop {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
+.hero-text {
+  flex: 1;
+  min-width: 0;
 }
 
-.info-tip:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:last-child .info-tip-pop {
-  left: auto;
-  right: 0;
-  transform: translateX(0);
+.hero-title {
+  margin: 0 0 0.25rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1, #111827);
+  line-height: 1.2;
 }
 
-.info-tip:nth-last-child(-n+2) .info-tip-pop::before,
-.info-tip:last-child .info-tip-pop::before {
-  left: auto;
-  right: 1rem;
-  transform: translateX(0) rotate(45deg);
-}
-
-.info-tip:hover:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:focus:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:hover:last-child .info-tip-pop,
-.info-tip:focus:last-child .info-tip-pop {
-  transform: translateX(0) translateY(0);
-}
-
-/* DMARC Table */
-.dmarc-table-section {
-  margin-top: 1.5rem;
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-}
-
-.dmarc-table-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.table-container {
-  overflow-x: auto;
-}
-
-.dmarc-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 1rem 0;
-  background: var(--vp-c-bg, #fff);
-}
-
-.dmarc-table th,
-.dmarc-table td {
-  border: 1px solid var(--vp-c-border-soft, #ddd);
-  padding: 0.75rem;
-  text-align: left;
-  vertical-align: top;
-}
-
-.dmarc-table th {
-  background: var(--vp-c-bg-soft, #f5f5f5);
-  font-weight: 600;
-}
-
-.tag-col { width: 80px; }
-.value-col { width: 200px; }
-.desc-col { width: auto; }
-
-.tag-cell { 
-  font-family: monospace; 
-  font-weight: 600;
-  color: var(--vp-c-brand);
-}
-
-.value-cell { 
-  font-family: monospace; 
+.hero-domain {
+  margin: 0;
+  font-size: 0.825rem;
+  color: var(--vp-c-text-2, #6b7280);
+  font-family: var(--vp-font-family-mono, monospace);
   word-break: break-all;
 }
 
-/* Standards Compliance Section */
-.protocol-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.protocol-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.protocol-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-}
-
-.policy-item {
+.hero-score {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 0.25rem;
-  padding: 0.75rem;
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 6px;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  overflow: visible;
+  flex-shrink: 0;
 }
 
-.policy-item .label {
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-weight: 500;
+.score-num {
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: var(--vp-c-text-1, #111827);
+  line-height: 1;
 }
 
-.policy-item .value {
-  color: var(--vp-c-text-1, #374151);
-  font-weight: 600;
+.score-denom {
   font-size: 1rem;
+  font-weight: 500;
+  color: var(--vp-c-text-3, #9ca3af);
 }
 
-.proto-badge {
-  display: inline-block;
-  padding: 0.15rem 0.6rem;
+.score-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.5rem;
   border-radius: 999px;
-  font-size: 0.78rem;
-  font-weight: 600;
 }
 
-.proto-badge.pass { background: #ebf7ed; color: #217b2d; }
-.proto-badge.warn { background: #fff8e6; color: #b45309; }
-.proto-badge.muted { background: var(--vp-c-bg-mute, #f1f5f9); color: var(--vp-c-text-2, #6b7280); }
+.score-strong, .score-excellent { background: rgba(22,163,74,0.12); color: #15803d; }
+.score-good,   .score-medium   { background: rgba(217,119,6,0.12);  color: #b45309; }
+.score-poor,   .score-weak     { background: rgba(220,38,38,0.1);   color: #dc2626; }
 
-/* Result Sections */
-.section {
-  margin-top: 1.5rem;
-  padding: 1.25rem;
+/* ── Signals grid ── */
+.signals-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.5rem;
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.signal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.625rem 0.25rem;
   border-radius: 8px;
+  text-align: center;
 }
 
-.section h4 {
-  margin: 0 0 1rem 0;
-  font-size: 1.25rem;
+.signal-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.signal-name {
+  font-size: 0.65rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-text-2, #6b7280);
 }
 
-.section ul {
-  margin: 0;
-  padding-left: 1.5rem;
+.signal-value {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1, #374151);
 }
 
-.section li {
-  margin: 0.5rem 0;
-  line-height: 1.5;
-}
+/* Signal states */
+.signal-strong .signal-icon { background: rgba(22,163,74,0.12); color: #16a34a; }
+.signal-medium .signal-icon { background: rgba(217,119,6,0.12);  color: #d97706; }
+.signal-weak   .signal-icon { background: rgba(220,38,38,0.1);   color: #dc2626; }
+.signal-muted  .signal-icon { background: var(--vp-c-bg-soft, #f3f4f6); color: var(--vp-c-text-3, #9ca3af); }
 
-.warnings-section {
-  background: var(--vp-warning-soft, #fffbf0);
-  border: 1px solid rgba(214, 158, 46, 0.2);
-}
+.signal-strong { background: rgba(22,163,74,0.04); }
+.signal-medium { background: rgba(217,119,6,0.04); }
+.signal-weak   { background: rgba(220,38,38,0.03); }
+.signal-muted  { background: transparent; }
 
-.warnings-section h4 {
-  color: var(--vp-c-warning-1, #d69e2e);
-}
-
-.recommendations-section {
-  background: var(--vp-tip-soft, #f0f9ff);
-  border: 1px solid rgba(23, 162, 184, 0.18);
-}
-
-.recommendations-section h4 {
-  color: var(--vp-c-tip-1, #17a2b8);
-}
-
-.test-mode-banner {
-  margin-top: 1.5rem;
+/* ── Alerts ── */
+.alert {
+  display: flex;
+  gap: 0.75rem;
   padding: 1rem 1.25rem;
-  background: #fff7ed;
-  border: 1px solid rgba(249, 115, 22, 0.2);
-  border-radius: 8px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+.alert > svg {
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.alert strong {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 0.2rem;
+}
+
+.alert p {
+  margin: 0;
+}
+
+.alert ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.alert li + li {
+  margin-top: 0.25rem;
+}
+
+.alert-testmode {
+  background: rgba(249,115,22,0.07);
+  border-color: rgba(249,115,22,0.25);
   color: #9a3412;
 }
 
-.test-mode-banner strong {
-  display: block;
-  font-size: 1rem;
-  font-weight: 700;
-  margin-bottom: 0.25rem;
+.alert-testmode > svg { color: #ea580c; }
+
+.alert-warn {
+  background: rgba(217,119,6,0.06);
+  border-color: rgba(217,119,6,0.2);
+  color: var(--vp-c-text-1, #374151);
 }
 
-.test-mode-banner p {
-  margin: 0;
-  font-size: 0.9rem;
+.alert-warn > svg { color: #d97706; }
+
+.alert-tip {
+  background: hsla(197, 87%, 50%, 0.05);
+  border-color: hsla(197, 87%, 50%, 0.2);
+  color: var(--vp-c-text-1, #374151);
+}
+
+.alert-tip > svg { color: var(--vp-c-brand-dark, #0891b2); }
+
+.alert-muted {
+  background: var(--vp-c-bg-soft, #f9fafb);
+  border-color: var(--vp-c-border, #e5e7eb);
+  color: var(--vp-c-text-2, #6b7280);
+}
+
+.alert-muted > svg { color: var(--vp-c-text-3, #9ca3af); }
+
+/* ── Disclosure (details/summary) ── */
+.disclosures {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.disclosure {
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.disclosure-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1.25rem;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.disclosure-trigger::-webkit-details-marker { display: none; }
+
+.disclosure-trigger:hover {
+  background: var(--vp-c-bg-soft, #f8f9fa);
+}
+
+.disclosure-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1, #374151);
+}
+
+.disclosure-chevron {
+  color: var(--vp-c-text-3, #9ca3af);
+  transition: transform 0.2s ease;
+}
+
+details[open] .disclosure-chevron {
+  transform: rotate(180deg);
+}
+
+.disclosure-body {
+  padding: 0 1.25rem 1.25rem;
+  border-top: 1px solid var(--vp-c-border-soft, #f1f5f9);
+}
+
+.raw-record {
+  display: block;
+  padding: 0.875rem 1rem;
+  margin-top: 1rem;
+  background: var(--vp-c-bg-soft, #f8f9fa);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 8px;
+  font-family: var(--vp-font-family-mono, monospace);
+  font-size: 0.8rem;
+  word-break: break-all;
+  white-space: pre-wrap;
+  line-height: 1.6;
+  color: var(--vp-c-text-1, #374151);
+}
+
+/* ── Tag table ── */
+.tag-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  font-size: 0.825rem;
+}
+
+.tag-table th {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-text-2, #6b7280);
+  border-bottom: 1px solid var(--vp-c-border, #e5e7eb);
+}
+
+.tag-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--vp-c-border-soft, #f1f5f9);
+  vertical-align: top;
+}
+
+.tag-table tr:last-child td {
+  border-bottom: none;
+}
+
+.td-tag {
+  font-family: monospace;
+  font-weight: 700;
+  color: var(--vp-c-brand);
+  white-space: nowrap;
+}
+
+.td-value {
+  font-family: monospace;
+  word-break: break-all;
+  color: var(--vp-c-text-1, #374151);
+}
+
+.td-desc {
+  color: var(--vp-c-text-2, #6b7280);
   line-height: 1.5;
 }
 
-.deprecated-section {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+/* ── Dark mode ── */
+.dark .hero-pass {
+  background: linear-gradient(135deg, rgba(22,163,74,0.09) 0%, rgba(19,176,238,0.06) 100%);
+  border-color: rgba(22,163,74,0.25);
 }
 
-.deprecated-section h4 {
-  color: var(--vp-c-text-2, #6b7280);
-  font-weight: 600;
+.dark .hero-fail {
+  background: rgba(220,38,38,0.08);
+  border-color: rgba(220,38,38,0.22);
 }
 
-.deprecated-section li {
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
+.dark .icon-pass {
+  background: rgba(22,163,74,0.18);
+  color: #4ade80;
+  border-color: rgba(22,163,74,0.25);
 }
 
-.advanced-section {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+.dark .icon-fail {
+  background: rgba(220,38,38,0.18);
+  color: #f87171;
+  border-color: rgba(220,38,38,0.2);
 }
 
-.advanced-section h4 {
-  color: var(--vp-c-text-2, #6b7280);
-  font-weight: 600;
+.dark .score-strong, .dark .score-excellent { background: rgba(22,163,74,0.2); color: #4ade80; }
+.dark .score-good,   .dark .score-medium   { background: rgba(217,119,6,0.2);  color: #fbbf24; }
+.dark .score-poor,   .dark .score-weak     { background: rgba(220,38,38,0.2);  color: #f87171; }
+
+.dark .signal-strong .signal-icon { background: rgba(22,163,74,0.2); color: #4ade80; }
+.dark .signal-medium .signal-icon { background: rgba(217,119,6,0.2);  color: #fbbf24; }
+.dark .signal-weak   .signal-icon { background: rgba(220,38,38,0.2);  color: #f87171; }
+
+.dark .alert-testmode {
+  background: rgba(249,115,22,0.12);
+  border-color: rgba(249,115,22,0.3);
+  color: #fdba74;
 }
 
-.advanced-section li {
-  color: var(--vp-c-text-2, #6b7280);
+.dark .alert-warn {
+  background: rgba(217,119,6,0.1);
+  border-color: rgba(217,119,6,0.25);
+  color: var(--vp-c-text-1);
 }
 
-/* Dark Mode */
-@media (prefers-color-scheme: dark) {
-  .dmarc-table th {
-    background: var(--vp-c-bg-soft, #252736);
-    color: var(--vp-c-text-1, #aad0f7);
-  }
-  
-  .refresh-captcha-btn {
-    background: var(--vp-c-bg-soft);
-    border-color: var(--vp-c-border);
-    color: var(--vp-c-text-1);
-  }
-  
-  .refresh-captcha-btn:hover:not(:disabled) {
-    border-color: var(--vp-c-brand);
-  }
-  
-  .recommendations-section,
-  .recommendations-section ul,
-  .recommendations-section li {
-    color: #2d3748 !important;
-  }
-
-  .test-mode-banner {
-    background: rgba(249, 115, 22, 0.12);
-    color: #fdba74;
-    border-color: rgba(249, 115, 22, 0.3);
-  }
-
-  .proto-badge.pass { background: rgba(34, 187, 51, 0.15); color: #6ee787; }
-  .proto-badge.warn { background: rgba(214, 158, 46, 0.15); color: #f0c36b; }
-
-  .info-tip-pop {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-    box-shadow: 0 8px 24px rgba(0,0,0,.3);
-  }
-  
-  .info-tip-pop::before {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-  }
+.dark .alert-tip {
+  background: hsla(197, 87%, 50%, 0.08);
+  border-color: hsla(197, 87%, 50%, 0.25);
+  color: var(--vp-c-text-1);
 }
 
-@media (max-width: 480px) {
-  .info-tip-pop {
-    position: fixed;
-    left: 10px !important;
-    right: 10px !important;
-    top: auto !important;
-    bottom: 20px;
-    transform: none !important;
-    width: auto !important;
-    max-width: none !important;
-    z-index: 9999;
-  }
-  
-  .info-tip-pop::before {
-    display: none;
-  }
-  
-  .info-tip:hover .info-tip-pop,
-  .info-tip:focus .info-tip-pop {
-    transform: none !important;
-  }
+.dark .alert-tip > svg { color: var(--vp-c-brand-light); }
+
+.dark .raw-record {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-brand-light);
 }
 
-/* Responsive */
-@media (max-width: 768px) {
-  .dmarc-checker {
-    padding: 0 0.5rem;
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  .signals-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
-  
-  .tool-form,
-  .result-section {
-    padding: 1rem;
-    margin: 1rem 0;
+
+  .hero {
+    padding: 1.25rem;
+    gap: 1rem;
   }
-  
-  .captcha-container {
+
+  .hero-score {
+    align-self: flex-start;
+  }
+
+  .search-form {
     flex-direction: column;
     align-items: stretch;
   }
-  
-  .refresh-captcha-btn {
-    align-self: center;
-  }
-  
-  .dmarc-table {
-    font-size: 0.875rem;
-  }
-  
-  .dmarc-table th,
-  .dmarc-table td {
-    padding: 0.5rem;
+
+  .search-btn {
+    width: 100%;
   }
 }
 
-@media (hover: none) and (pointer: coarse) {
-  .info-tip {
-    width: 1.25rem;
-    height: 1.25rem;
-    line-height: 1.25rem;
+@media (max-width: 400px) {
+  .signals-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
-  
-  .info-tip-pop {
-    padding: 1rem 1.25rem;
-    font-size: .875rem;
+
+  .hero {
+    flex-wrap: wrap;
   }
 }
 </style>

--- a/.vitepress/theme/free-tools/DmarcChecker.vue
+++ b/.vitepress/theme/free-tools/DmarcChecker.vue
@@ -216,14 +216,6 @@ onMounted(async () => {
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
-        <Turnstile
-          ref="turnstileRef"
-          class="turnstile-inline"
-          :class="{ 'turnstile-collapsed': result }"
-          @verified="onTurnstileVerified"
-          @expired="onTurnstileInvalid"
-          @error="onTurnstileInvalid"
-        />
         <button type="submit" class="search-btn" :disabled="isFormDisabled">
           <span v-if="loading" class="btn-loading">
             <span class="spinner"></span>
@@ -231,6 +223,15 @@ onMounted(async () => {
           <span v-else>Check DMARC</span>
         </button>
       </form>
+
+      <Turnstile
+        ref="turnstileRef"
+        class="turnstile-row"
+        :class="{ 'turnstile-collapsed': result }"
+        @verified="onTurnstileVerified"
+        @expired="onTurnstileInvalid"
+        @error="onTurnstileInvalid"
+      />
     </div>
 
     <!-- ── Error ── -->
@@ -461,16 +462,18 @@ onMounted(async () => {
   cursor: not-allowed;
 }
 
-.turnstile-inline {
-  flex-shrink: 0;
-  transition: opacity 0.2s, max-width 0.2s, max-height 0.2s, margin 0.2s;
+.turnstile-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.75rem;
+  transition: opacity 0.2s, max-height 0.2s, margin 0.2s;
   overflow: hidden;
 }
 
-.turnstile-inline.turnstile-collapsed {
+.turnstile-row.turnstile-collapsed {
   opacity: 0;
-  max-width: 0;
   max-height: 0;
+  margin-top: 0;
   pointer-events: none;
   position: absolute;
 }

--- a/.vitepress/theme/free-tools/DmarcChecker.vue
+++ b/.vitepress/theme/free-tools/DmarcChecker.vue
@@ -150,11 +150,11 @@ function validateInputs() {
 }
 
 async function checkDmarcHandler() {
-  result.value      = null
-  loading.value     = true
+  result.value = null
+  loading.value = true
   errorMessage.value = ''
   showRawRecord.value = false
-  showTagTable.value  = false
+  showTagTable.value = false
 
   try {
     if (!validateInputs()) {

--- a/.vitepress/theme/free-tools/DmarcChecker.vue
+++ b/.vitepress/theme/free-tools/DmarcChecker.vue
@@ -51,43 +51,63 @@ const dmarcTags = computed(() => {
 
 const policySignal = computed(() => {
   const p = result.value?.parsed?.p?.toLowerCase()
-  if (p === 'reject')      return { label: 'Reject',      level: 'strong',  icon: 'check' }
-  if (p === 'quarantine')  return { label: 'Quarantine',  level: 'medium',  icon: 'minus' }
-  if (p === 'none')        return { label: 'None',        level: 'weak',    icon: 'alert' }
+  if (p === 'reject') {
+    return { label: 'Reject', level: 'strong', icon: 'check' }
+  }
+  if (p === 'quarantine') {
+    return { label: 'Quarantine', level: 'medium', icon: 'minus' }
+  }
+  if (p === 'none') {
+    return { label: 'None', level: 'weak', icon: 'alert' }
+  }
   return null
 })
 
 const pctSignal = computed(() => {
   const pct = result.value?.parsed?.pct
-  if (!pct) return { label: '100% (default)', level: 'strong', icon: 'check' }
+  if (!pct) {
+    return { label: '100% (default)', level: 'strong', icon: 'check' }
+  }
   const n = parseInt(pct, 10)
-  if (n === 100) return { label: '100%',      level: 'strong', icon: 'check' }
-  if (n >= 50)   return { label: `${n}%`,     level: 'medium', icon: 'minus' }
-  return         { label: `${n}%`,            level: 'weak',   icon: 'alert' }
+  if (n === 100) {
+    return { label: '100%', level: 'strong', icon: 'check' }
+  }
+  if (n >= 50) {
+    return { label: `${n}%`, level: 'medium', icon: 'minus' }
+  }
+  return { label: `${n}%`, level: 'weak', icon: 'alert' }
 })
 
 const dkimAlignSignal = computed(() => {
   const adkim = result.value?.parsed?.adkim?.toLowerCase()
-  if (adkim === 's') return { label: 'DKIM Strict',  level: 'strong', icon: 'check' }
-  return               { label: 'DKIM Relaxed', level: 'medium', icon: 'minus' }
+  if (adkim === 's') {
+    return { label: 'DKIM Strict', level: 'strong', icon: 'check' }
+  }
+  return { label: 'DKIM Relaxed', level: 'medium', icon: 'minus' }
 })
 
 const spfAlignSignal = computed(() => {
   const aspf = result.value?.parsed?.aspf?.toLowerCase()
-  if (aspf === 's') return { label: 'SPF Strict',  level: 'strong', icon: 'check' }
-  return              { label: 'SPF Relaxed', level: 'medium', icon: 'minus' }
+  if (aspf === 's') {
+    return { label: 'SPF Strict', level: 'strong', icon: 'check' }
+  }
+  return { label: 'SPF Relaxed', level: 'medium', icon: 'minus' }
 })
 
 const ruaSignal = computed(() => {
   const rua = result.value?.parsed?.rua
-  if (rua) return { label: 'Reports On',  level: 'strong', icon: 'check' }
-  return    { label: 'No Reports',   level: 'weak',   icon: 'alert' }
+  if (rua) {
+    return { label: 'Reports On', level: 'strong', icon: 'check' }
+  }
+  return { label: 'No Reports', level: 'weak', icon: 'alert' }
 })
 
 const rufSignal = computed(() => {
   const ruf = result.value?.parsed?.ruf
-  if (ruf) return { label: 'Forensics On', level: 'medium', icon: 'minus' }
-  return    { label: 'No Forensics', level: 'muted',  icon: 'dot' }
+  if (ruf) {
+    return { label: 'Forensics On', level: 'medium', icon: 'minus' }
+  }
+  return { label: 'No Forensics', level: 'muted', icon: 'dot' }
 })
 
 const criticalWarnings = computed(() =>
@@ -108,8 +128,13 @@ const recommendations = computed(() =>
   result.value?.recommendations ?? []
 )
 
-function onTurnstileVerified(token)  { turnstileToken.value = token }
-function onTurnstileInvalid()        { turnstileToken.value = '' }
+function onTurnstileVerified(token) {
+  turnstileToken.value = token
+}
+
+function onTurnstileInvalid() {
+  turnstileToken.value = ''
+}
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -132,7 +157,10 @@ async function checkDmarcHandler() {
   showTagTable.value  = false
 
   try {
-    if (!validateInputs()) { loading.value = false; return }
+    if (!validateInputs()) {
+      loading.value = false
+      return
+    }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
@@ -159,7 +187,9 @@ async function checkDmarcHandler() {
     resetTurnstile()
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) resetTurnstile()
+    if (err.status === 401) {
+      resetTurnstile()
+    }
   } finally {
     loading.value = false
   }

--- a/.vitepress/theme/free-tools/DmarcChecker.vue
+++ b/.vitepress/theme/free-tools/DmarcChecker.vue
@@ -8,42 +8,42 @@ import SignalIcon from './SignalIcon.vue'
 import ToolSwitcher from './ToolSwitcher.vue'
 
 const DMARC_TAG_DESCRIPTIONS = {
-  v:     'DMARC version tag (should be DMARC1).',
-  p:     'Policy for main domain (none/quarantine/reject).',
-  sp:    'Subdomain policy (if present).',
-  np:    'Policy for non-existent subdomains.',
-  rua:   'Aggregate report recipient(s).',
-  ruf:   'Forensic report recipient(s).',
+  v: 'DMARC version tag (should be DMARC1).',
+  p: 'Policy for main domain (none/quarantine/reject).',
+  sp: 'Subdomain policy (if present).',
+  np: 'Policy for non-existent subdomains.',
+  rua: 'Aggregate report recipient(s).',
+  ruf: 'Forensic report recipient(s).',
   adkim: 'DKIM alignment mode (r=relaxed, s=strict).',
-  aspf:  'SPF alignment mode (r=relaxed, s=strict).',
-  pct:   'Percent of mail subject to filtering.',
-  fo:    'Failure reporting options.',
-  ri:    'Report interval in seconds.',
-  t:     'Test mode flag (y = testing, policy not enforced).',
-  psd:   'Public suffix domain flag.',
-  rf:    'Report format (deprecated).',
+  aspf: 'SPF alignment mode (r=relaxed, s=strict).',
+  pct: 'Percent of mail subject to filtering.',
+  fo: 'Failure reporting options.',
+  ri: 'Report interval in seconds.',
+  t: 'Test mode flag (y = testing, policy not enforced).',
+  psd: 'Public suffix domain flag.',
+  rf: 'Report format (deprecated).',
 }
 
-const domain        = ref('')
-const loading       = ref(false)
-const result        = ref(null)
-const errorMessage  = ref('')
+const domain = ref('')
+const loading = ref(false)
+const result = ref(null)
+const errorMessage = ref('')
 const showRawRecord = ref(false)
-const showTagTable  = ref(false)
+const showTagTable = ref(false)
 
-const turnstileRef   = ref(null)
+const turnstileRef = ref(null)
 const turnstileToken = ref('')
 const resultsRef = ref(null)
 
 const isFormDisabled = computed(() => loading.value)
 
 const dmarcTags = computed(() => {
-  const parsed       = result.value?.parsed       || {}
+  const parsed = result.value?.parsed || {}
   const explanations = result.value?.explanations || {}
   return Object.entries(DMARC_TAG_DESCRIPTIONS)
     .map(([tag, description]) => ({
-      tag:         tag.toUpperCase(),
-      value:       parsed[tag] || '',
+      tag: tag.toUpperCase(),
+      value: parsed[tag] || '',
       description: explanations[tag] || description,
     }))
     .filter(item => item.value)
@@ -167,20 +167,20 @@ async function checkDmarcHandler() {
     }
 
     const data = await checkDmarc({
-      domain:         domain.value,
+      domain: domain.value,
       turnstileToken: turnstileToken.value,
     })
 
     result.value = {
-      valid:        true,
-      domain:       data.result.domain       || domain.value,
-      record:       data.result.rawRecord    || data.result.record || 'Not found',
-      parsed:       data.result.parsed       || {},
+      valid: true,
+      domain: data.result.domain || domain.value,
+      record: data.result.rawRecord || data.result.record || 'Not found',
+      parsed: data.result.parsed || {},
       explanations: data.result.explanations || {},
       checkedRecord: data.result.checkedRecord,
-      score:        data.result.score,
-      protocol:     data.result.protocol     || null,
-      warnings:     data.result.warnings     || [],
+      score: data.result.score,
+      protocol: data.result.protocol || null,
+      warnings: data.result.warnings || [],
       recommendations: data.result.recommendations || [],
     }
 

--- a/.vitepress/theme/free-tools/DmarcChecker.vue
+++ b/.vitepress/theme/free-tools/DmarcChecker.vue
@@ -217,7 +217,7 @@ onMounted(async () => {
 
     <ToolSwitcher :domain="domain" />
 
-    <!-- ── Inline form ── -->
+    <!-- Inline form -->
     <div class="search-bar" :class="{ 'has-result': result }">
       <form class="search-form" @submit.prevent="checkDmarcHandler">
         <div class="search-input-wrap">
@@ -264,13 +264,13 @@ onMounted(async () => {
       />
     </div>
 
-    <!-- ── Error ── -->
+    <!-- Error -->
     <div v-if="errorMessage" class="error-pill">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
       {{ errorMessage }}
     </div>
 
-    <!-- ── Results ── -->
+    <!-- Results -->
     <div v-if="result" class="results" ref="resultsRef">
 
       <!-- Hero status -->
@@ -399,7 +399,7 @@ onMounted(async () => {
 </template>
 
 <style scoped>
-/* ── Root ── */
+/* Root */
 .dmarc-checker {
   max-width: 780px;
   margin: 0 auto;
@@ -407,7 +407,7 @@ onMounted(async () => {
   font-family: inherit;
 }
 
-/* ── Search bar ── */
+/* Search bar */
 .search-bar {
   margin: 2rem 0 1.5rem;
   transition: margin 0.2s;
@@ -563,7 +563,7 @@ onMounted(async () => {
 
 @keyframes spin { to { transform: rotate(360deg); } }
 
-/* ── Error ── */
+/* Error */
 .error-pill {
   display: inline-flex;
   align-items: center;
@@ -578,14 +578,14 @@ onMounted(async () => {
   margin-bottom: 1.5rem;
 }
 
-/* ── Results ── */
+/* Results */
 .results {
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
 }
 
-/* ── Hero ── */
+/* Hero */
 .hero {
   display: flex;
   align-items: center;
@@ -682,7 +682,7 @@ onMounted(async () => {
 .score-good,   .score-medium   { background: rgba(217,119,6,0.12);  color: #b45309; }
 .score-poor,   .score-weak     { background: rgba(220,38,38,0.1);   color: #dc2626; }
 
-/* ── Signals grid ── */
+/* Signals grid */
 .signals-grid {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
@@ -738,7 +738,7 @@ onMounted(async () => {
 .signal-weak   { background: rgba(220,38,38,0.03); }
 .signal-muted  { background: transparent; }
 
-/* ── Alerts ── */
+/* Alerts */
 .alert {
   display: flex;
   gap: 0.75rem;
@@ -805,7 +805,7 @@ onMounted(async () => {
 
 .alert-muted > svg { color: var(--vp-c-text-3, #9ca3af); }
 
-/* ── Disclosure (details/summary) ── */
+/* Disclosure (details/summary) */
 .disclosures {
   display: flex;
   flex-direction: column;
@@ -870,7 +870,7 @@ details[open] .disclosure-chevron {
   color: var(--vp-c-text-1, #374151);
 }
 
-/* ── Tag table ── */
+/* Tag table */
 .tag-table {
   width: 100%;
   border-collapse: collapse;
@@ -917,7 +917,7 @@ details[open] .disclosure-chevron {
   line-height: 1.5;
 }
 
-/* ── Dark mode ── */
+/* Dark mode */
 .dark .hero-pass {
   background: linear-gradient(135deg, rgba(22,163,74,0.09) 0%, rgba(19,176,238,0.06) 100%);
   border-color: rgba(22,163,74,0.25);
@@ -973,7 +973,7 @@ details[open] .disclosure-chevron {
   color: var(--vp-c-brand-light);
 }
 
-/* ── Responsive ── */
+/* Responsive */
 @media (max-width: 640px) {
   .signals-grid {
     grid-template-columns: repeat(3, 1fr);

--- a/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
+++ b/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
@@ -307,7 +307,7 @@ onMounted(async () => { await nextTick() })
       </div>
 
       <!-- Auth breakdown -->
-      <div v-if="result.authSummary" class="card">
+      <div v-if="result.authSummary" class="tool-card">
         <h3 class="card-title">
           Authentication Breakdown
           <span class="tip" tabindex="0">?<span class="tip-pop">DMARC needs authentication AND alignment. "Passed, not aligned" means the check succeeded but for the wrong domain — it does not count toward DMARC.</span></span>
@@ -409,7 +409,7 @@ onMounted(async () => { await nextTick() })
       </div>
 
       <!-- Email sources table -->
-      <div v-if="result.sources?.length" class="card">
+      <div v-if="result.sources?.length" class="tool-card">
         <h3 class="card-title">
           Email Sources
           <span class="tip" tabindex="0">?<span class="tip-pop">IP addresses that sent email claiming to be from your domain, with their authentication results.</span></span>
@@ -911,7 +911,7 @@ onMounted(async () => { await nextTick() })
 }
 
 /* Card */
-.card {
+.tool-card {
   background: var(--vp-c-bg, #fff);
   border: 1px solid var(--vp-c-border, #e5e7eb);
   border-radius: 12px;

--- a/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
+++ b/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
@@ -4,154 +4,86 @@ import { analyzeDmarcReport } from '../../../connectors/bluefoxEmailToolsApi.js'
 import { isSessionValid } from '../../../connectors/turnstileSession.js'
 import Turnstile from './Turnstile.vue'
 
-// ---- VARIABLES ----
 const MAX_FILENAME_LEN = 30
 
-const xmlPaste = ref('')
-const file = ref(null)
-const fileName = ref('')
-const loading = ref(false)
-const result = ref(null)
+const xmlPaste  = ref('')
+const file      = ref(null)
+const fileName  = ref('')
+const loading   = ref(false)
+const result    = ref(null)
 const errorMessage = ref('')
 
-// Drag and drop state
 const isDragging = ref(false)
 let dragLeaveTimeout = null
 
-// Turnstile state
-const turnstileRef = ref(null)
+const fileInputRef   = ref(null)
+const turnstileRef   = ref(null)
 const turnstileToken = ref('')
 
-// Result display state
 const expandedSources = ref(new Set())
-const showRecords = ref(false)
+const showRecords     = ref(false)
 
-// Computed properties
 const isFormDisabled = computed(() =>
   loading.value || (!xmlPaste.value.trim() && !file.value)
 )
 
 const truncatedFileName = computed(() => {
-  if (!fileName.value) {
-    return ''
-  }
-  if (fileName.value.length <= MAX_FILENAME_LEN) {
-    return fileName.value
-  }
+  if (!fileName.value) return ''
+  if (fileName.value.length <= MAX_FILENAME_LEN) return fileName.value
   return `${fileName.value.slice(0, 15)}...${fileName.value.slice(-10)}`
 })
 
-const hasEnvelopeFrom = computed(() =>
-  result.value?.sources?.some(s => s.envelopeFrom != null) ?? false
-)
-
-const hasSpfScope = computed(() =>
-  result.value?.sources?.some(s => s.spfScope != null) ?? false
-)
-
-// New API returns alignment fields per source; old responses don't.
-const hasAlignmentData = computed(() =>
-  result.value?.sources?.some(s => s.spfAlignment !== undefined) ?? false
-)
+const hasEnvelopeFrom  = computed(() => result.value?.sources?.some(s => s.envelopeFrom != null) ?? false)
+const hasSpfScope      = computed(() => result.value?.sources?.some(s => s.spfScope != null) ?? false)
+const hasAlignmentData = computed(() => result.value?.sources?.some(s => s.spfAlignment !== undefined) ?? false)
 
 const sourcesGridColumns = computed(() => {
   const cols = ['2fr', '1.5fr', '0.7fr', '1fr', '1fr', '1fr']
   if (hasAlignmentData.value) {
     cols.push('1.2fr', '1.2fr', '0.5fr')
   } else {
-    if (hasEnvelopeFrom.value) {
-      cols.push('2fr')
-    }
-    if (hasSpfScope.value) {
-      cols.push('1fr')
-    }
+    if (hasEnvelopeFrom.value) cols.push('2fr')
+    if (hasSpfScope.value)     cols.push('1fr')
   }
   return cols.join(' ')
 })
 
-const dkimWarnings = computed(() =>
-  result.value?.warnings?.filter(w => /dkim.*selector|selector.*dkim/i.test(w)) ?? []
-)
+const dkimWarnings    = computed(() => result.value?.warnings?.filter(w => /dkim.*selector|selector.*dkim/i.test(w)) ?? [])
+const regularWarnings = computed(() => result.value?.warnings?.filter(w => !/dkim.*selector|selector.*dkim/i.test(w)) ?? [])
 
-const regularWarnings = computed(() =>
-  result.value?.warnings?.filter(w => !/dkim.*selector|selector.*dkim/i.test(w)) ?? []
-)
-
-const testModeRecommendations = computed(() =>
-  result.value?.recommendations?.filter(r => /policy[_\s]?test[_\s]?mode|test\s?mode/i.test(r)) ?? []
-)
-
+const testModeRecommendations  = computed(() => result.value?.recommendations?.filter(r => /policy[_\s]?test[_\s]?mode|test\s?mode/i.test(r)) ?? [])
 const forwardingRecommendations = computed(() =>
-  result.value?.recommendations?.filter(r =>
-    /forwarded mail|forwarding/i.test(r) && !/policy[_\s]?test[_\s]?mode/i.test(r)
-  ) ?? []
+  result.value?.recommendations?.filter(r => /forwarded mail|forwarding/i.test(r) && !/policy[_\s]?test[_\s]?mode/i.test(r)) ?? []
 )
-
 const regularRecommendations = computed(() =>
   result.value?.recommendations?.filter(r =>
-    !/policy[_\s]?test[_\s]?mode|test\s?mode/i.test(r) &&
-    !forwardingRecommendations.value.includes(r)
+    !/policy[_\s]?test[_\s]?mode|test\s?mode/i.test(r) && !forwardingRecommendations.value.includes(r)
   ) ?? []
 )
 
-// ---- ALIGNMENT / DISPLAY HELPERS ----
-const ALIGNMENT_LABELS = {
-  aligned: 'Aligned',
-  unaligned: 'Not aligned',
-  mixed: 'Mixed',
-  no_data: 'No data'
-}
+const ALIGNMENT_LABELS  = { aligned: 'Aligned', unaligned: 'Not aligned', mixed: 'Mixed', no_data: 'No data' }
+const ALIGNMENT_CLASSES = { aligned: 'pass', unaligned: 'fail', mixed: 'warn', no_data: 'muted' }
 
-const ALIGNMENT_CLASSES = {
-  aligned: 'pass',
-  unaligned: 'fail',
-  mixed: 'warn',
-  no_data: 'muted'
-}
-
-function alignmentLabel(value) {
-  return ALIGNMENT_LABELS[value] || value || '-'
-}
-
-function alignmentClass(value) {
-  return ALIGNMENT_CLASSES[value] || 'muted'
-}
+function alignmentLabel(v) { return ALIGNMENT_LABELS[v] || v || '-' }
+function alignmentClass(v) { return ALIGNMENT_CLASSES[v] || 'muted' }
 
 function authDotClass(status) {
-  if (status === 'aligned_pass') {
-    return 'pass'
-  }
-  if (status === 'unaligned_pass') {
-    return 'warn'
-  }
-  if (status === 'auth_fail') {
-    return 'fail'
-  }
+  if (status === 'aligned_pass')   return 'pass'
+  if (status === 'unaligned_pass') return 'warn'
+  if (status === 'auth_fail')      return 'fail'
   return 'muted'
 }
 
 function toggleSource(ip) {
   const next = new Set(expandedSources.value)
-  if (next.has(ip)) {
-    next.delete(ip)
-  } else {
-    next.add(ip)
-  }
+  next.has(ip) ? next.delete(ip) : next.add(ip)
   expandedSources.value = next
 }
 
-function isSourceExpanded(ip) {
-  return expandedSources.value.has(ip)
-}
+function isSourceExpanded(ip) { return expandedSources.value.has(ip) }
 
-// ---- FUNCTIONS ----
-function onTurnstileVerified(token) {
-  turnstileToken.value = token
-}
-
-function onTurnstileInvalid() {
-  turnstileToken.value = ''
-}
+function onTurnstileVerified(token) { turnstileToken.value = token }
+function onTurnstileInvalid()       { turnstileToken.value = '' }
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -163,31 +95,24 @@ function validateInputs() {
     errorMessage.value = 'Please paste your DMARC XML or upload an XML file to analyze.'
     return false
   }
-
   return true
 }
 
-// Drag and drop handlers
 function handleDragOver(e) {
   e.preventDefault()
-  if (dragLeaveTimeout) {
-    clearTimeout(dragLeaveTimeout)
-  }
+  if (dragLeaveTimeout) clearTimeout(dragLeaveTimeout)
   isDragging.value = true
 }
 
 function handleDragLeave(e) {
   e.preventDefault()
-  dragLeaveTimeout = setTimeout(() => {
-    isDragging.value = false
-  }, 30)
+  dragLeaveTimeout = setTimeout(() => { isDragging.value = false }, 30)
 }
 
 function handleDrop(e) {
   e.preventDefault()
   isDragging.value = false
   const dropped = e.dataTransfer.files[0]
-  
   if (dropped && dropped.name.endsWith('.xml')) {
     file.value = dropped
     fileName.value = dropped.name
@@ -198,21 +123,14 @@ function handleDrop(e) {
   }
 }
 
-// File handling
 function handleFileChange(e) {
   const selected = e.target.files[0]
-  
-  if (!selected) {
-    clearFile()
-    return
-  }
-  
+  if (!selected) { clearFile(); return }
   if (!selected.name.endsWith('.xml')) {
     errorMessage.value = 'Only XML files are supported.'
     clearFile()
     return
   }
-  
   file.value = selected
   fileName.value = selected.name
   xmlPaste.value = ''
@@ -225,36 +143,27 @@ function clearFile() {
   errorMessage.value = ''
 }
 
-// Format helpers
 function formatDateRange(dateRange) {
-  if (!dateRange) {
-    return 'Unknown'
-  }
+  if (!dateRange) return 'Unknown'
   if (dateRange.start && dateRange.end) {
-    return `${new Date(dateRange.start * 1000).toLocaleString()} to ${new Date(dateRange.end * 1000).toLocaleString()}`
+    return `${new Date(dateRange.start * 1000).toLocaleString()} – ${new Date(dateRange.end * 1000).toLocaleString()}`
   }
   return typeof dateRange === 'string' ? dateRange : 'Unknown'
 }
 
 function formatOverride(reason) {
-  if (reason.comment) {
-    return `${reason.type} (${reason.comment})`
-  }
-  return reason.type
+  return reason.comment ? `${reason.type} (${reason.comment})` : reason.type
 }
 
 async function analyzeReport() {
-  result.value = null
+  result.value         = null
   expandedSources.value = new Set()
-  showRecords.value = false
-  loading.value = true
-  errorMessage.value = ''
+  showRecords.value    = false
+  loading.value        = true
+  errorMessage.value   = ''
 
   try {
-    if (!validateInputs()) {
-      loading.value = false
-      return
-    }
+    if (!validateInputs()) { loading.value = false; return }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
@@ -263,1311 +172,808 @@ async function analyzeReport() {
     const data = await analyzeDmarcReport({
       xmlContent: file.value ? null : xmlPaste.value,
       file: file.value,
-      turnstileToken: turnstileToken.value
+      turnstileToken: turnstileToken.value,
     })
 
     const { session, ...analysis } = data.result
-
-    result.value = {
-      ...analysis,
-      valid: true
-    }
+    result.value = { ...analysis, valid: true }
 
     resetTurnstile()
     clearFile()
-
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) {
-      resetTurnstile()
-    }
+    if (err.status === 401) resetTurnstile()
   } finally {
     loading.value = false
   }
 }
 
-// ---- LIFECYCLE ----
-onMounted(async () => {
-  await nextTick()
-})
+onMounted(async () => { await nextTick() })
 </script>
 
 <template>
   <div class="dmarc-analyzer">
-    <div class="tool-form">
-      <form @submit.prevent="analyzeReport">
-        <!-- Form fields container with drag overlay -->
-        <div 
-          class="form-fields-container"
-          :class="{ 'drag-hover': isDragging }"
-          @dragover="handleDragOver"
-          @dragleave="handleDragLeave"
-          @drop="handleDrop"
-        >
-          <!-- Drag overlay covers only form fields area -->
-          <div v-if="isDragging" class="drag-overlay-fields">
-            <div class="drag-content">
-              <div class="drag-icon">📁</div>
-              <span class="drag-text">Drop XML file here</span>
-              <small class="drag-subtext">Release to upload</small>
-            </div>
-          </div>
 
-          <!-- XML Paste Input -->
-          <div class="form-group">
-            <label for="xmlPaste">Paste DMARC Report XML:</label>
-            <textarea
-              id="xmlPaste"
-              v-model="xmlPaste"
-              rows="8"
-              placeholder="Paste your DMARC XML here..."
-              :disabled="!!file || loading"
-              autocomplete="off"
-              autocorrect="off"
-            />
-          </div>
-
-          <!-- File Upload / Drag & Drop -->
-          <div class="form-group">
-            <label>Or Upload XML File:</label>
-            <div class="file-upload-area">
-              <input
-                type="file"
-                accept=".xml"
-                @change="handleFileChange"
-                :disabled="!!xmlPaste || loading"
-                style="display: none;"
-                id="fileInput"
-              />
-              <template v-if="!fileName">
-                <label
-                  for="fileInput"
-                  class="file-upload-label"
-                  :class="{ disabled: !!xmlPaste || loading }"
-                >
-                  Click to select XML file or drag anywhere in this area
-                </label>
-              </template>
-              <div v-else class="file-name-row">
-                <span class="file-name" :title="fileName">{{ truncatedFileName }}</span>
-                <button
-                  type="button"
-                  class="remove-file-btn"
-                  @click="clearFile"
-                  :disabled="loading"
-                >
-                  Remove
-                </button>
-              </div>
-            </div>
-          </div>
+    <!-- ── Upload form ── -->
+    <div class="upload-card"
+      :class="{ 'drag-active': isDragging }"
+      @dragover="handleDragOver"
+      @dragleave="handleDragLeave"
+      @drop="handleDrop"
+    >
+      <!-- Drag overlay -->
+      <div v-if="isDragging" class="drag-overlay">
+        <div class="drag-content">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+          <span>Drop XML file here</span>
         </div>
+      </div>
 
-        <!-- Verification -->
+      <form @submit.prevent="analyzeReport">
+        <!-- Paste area -->
         <div class="form-group">
-          <Turnstile
-            ref="turnstileRef"
-            @verified="onTurnstileVerified"
-            @expired="onTurnstileInvalid"
-            @error="onTurnstileInvalid"
+          <label for="xmlPaste">Paste DMARC Report XML</label>
+          <textarea
+            id="xmlPaste"
+            v-model="xmlPaste"
+            rows="8"
+            placeholder="Paste your DMARC aggregate report XML here..."
+            :disabled="!!file || loading"
+            autocomplete="off"
+            autocorrect="off"
           />
         </div>
 
-        <!-- Submit Button -->
-        <button type="submit" class="check-btn" :disabled="isFormDisabled">
-          <span v-if="loading" class="btn-loading">
-            <div class="loading-spinner"></div>
-            Analyzing...
-          </span>
+        <!-- File upload -->
+        <div class="form-group">
+          <label>Or upload XML file</label>
+          <div class="file-zone">
+            <input ref="fileInputRef" type="file" accept=".xml" @change="handleFileChange"
+              :disabled="!!xmlPaste || loading" style="display:none" />
+            <template v-if="!fileName">
+              <div
+                class="file-label"
+                :class="{ disabled: !!xmlPaste || loading }"
+                role="button"
+                tabindex="0"
+                @click="!xmlPaste && !loading && fileInputRef.click()"
+                @keydown.enter="!xmlPaste && !loading && fileInputRef.click()"
+                @keydown.space.prevent="!xmlPaste && !loading && fileInputRef.click()"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                <span>Click to select or drag &amp; drop XML</span>
+              </div>
+            </template>
+            <div v-else class="file-selected">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+              <span class="file-name" :title="fileName">{{ truncatedFileName }}</span>
+              <button type="button" class="file-remove" @click="clearFile" :disabled="loading">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <Turnstile ref="turnstileRef" @verified="onTurnstileVerified" @expired="onTurnstileInvalid" @error="onTurnstileInvalid" />
+
+        <button type="submit" class="submit-btn" :disabled="isFormDisabled">
+          <span v-if="loading" class="btn-loading"><span class="spinner"></span> Analyzing...</span>
           <span v-else>Analyze Report</span>
         </button>
       </form>
     </div>
 
-    <!-- Error Display -->
-    <div v-if="errorMessage" class="error-section">
-      <p class="error-message">{{ errorMessage }}</p>
+    <!-- ── Error ── -->
+    <div v-if="errorMessage" class="error-pill">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      {{ errorMessage }}
     </div>
 
-    <!-- Results Section -->
-    <div v-if="result" class="result-section">
-      <h3>DMARC Report Analysis</h3>
+    <!-- ── Results ── -->
+    <div v-if="result" class="results">
 
-      <!-- Summary -->
-      <div class="info-section">
-        <h4>
-          Report Summary
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Key metrics and details extracted from the DMARC aggregate report.</span>
-          </span>
-        </h4>
-        <div class="summary-grid">
-          <div class="summary-item">
-            <span class="label">Email Provider:</span>
-            <span class="value">
-              {{ result.emailProvider || result.organization || 'Unknown' }}
-              <span class="info-tip" tabindex="0">
-                ?
-                <span class="info-tip-pop">The organization that sent this DMARC report (usually the receiving mail server).</span>
-              </span>
-            </span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Domain:</span>
-            <span class="value">{{ result.domain || 'Unknown' }}</span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Report Date:</span>
-            <span class="value">
-              {{ result.reportDate ? new Date(result.reportDate).toLocaleString() : 'Unknown' }}
-            </span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Report ID:</span>
-            <span class="value monospace" :title="result.reportId || 'Unknown'">
-              {{ result.reportId || 'Unknown' }}
-            </span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Messages:</span>
-            <span class="value">
-              {{ result.totalMessages }}
-              <span class="info-tip" tabindex="0">
-                ?
-                <span class="info-tip-pop">Total number of email messages included in this DMARC report.</span>
-              </span>
-            </span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Pass Rate:</span>
-            <span class="value">
-              {{ result.passRate }}%
-              <span class="info-tip" tabindex="0">
-                ?
-                <span class="info-tip-pop">Percentage of messages that passed DMARC authentication (either SPF or DKIM aligned).</span>
-              </span>
-            </span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Date Range:</span>
-            <span class="value">{{ formatDateRange(result.dateRange) }}</span>
-          </div>
-          <div v-if="result.score" class="summary-item">
-            <span class="label">Score:</span>
-            <span class="value">
-              {{ result.score.value }}/{{ result.score.outOf }} ({{ result.score.level }})
-              <span class="info-tip" tabindex="0">
-                ?
-                <span class="info-tip-pop">Overall assessment of your DMARC authentication performance based on pass rates and configurations.</span>
-              </span>
-            </span>
-          </div>
-          <div v-if="result.version" class="summary-item">
-            <span class="label">Report Version:</span>
-            <span class="value">{{ result.version }}</span>
-          </div>
-          <div v-if="result.generator" class="summary-item">
-            <span class="label">Generator:</span>
-            <span class="value">{{ result.generator }}</span>
-          </div>
-          <div v-if="result.likelyForwardedCount" class="summary-item">
-            <span class="label">Likely Forwarded:</span>
-            <span class="value">
-              {{ result.likelyForwardedCount }}
-              <span class="info-tip" tabindex="0">
-                ?
-                <span class="info-tip-pop">Messages where DKIM passed and aligned but SPF failed. This is the typical fingerprint of forwarded mail, not a misconfiguration.</span>
-              </span>
-            </span>
-          </div>
+      <!-- Hero -->
+      <div class="hero" :class="(result.passRate ?? 0) >= 90 ? 'hero-pass' : (result.passRate ?? 0) >= 50 ? 'hero-warn' : 'hero-fail'">
+        <div class="hero-icon" :class="(result.passRate ?? 0) >= 90 ? 'icon-pass' : (result.passRate ?? 0) >= 50 ? 'icon-warn' : 'icon-fail'">
+          <svg v-if="(result.passRate ?? 0) >= 90" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20 6 9 17 4 12"/></svg>
+          <svg v-else-if="(result.passRate ?? 0) >= 50" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          <svg v-else width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </div>
-      </div>
-
-      <!-- Authentication Breakdown -->
-      <div v-if="result.authSummary" class="auth-summary-section">
-        <h4>
-          Authentication Breakdown
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">DMARC needs authentication AND alignment. "Passed, not aligned" means the check succeeded but for the wrong domain, so it does not count toward DMARC.</span>
-          </span>
-        </h4>
-        <div class="auth-summary-grid">
-          <div class="auth-card">
-            <div class="auth-card-title">
-              SPF
-              <span v-if="result.alignmentMode" class="alignment-mode-badge">{{ result.alignmentMode.spf }} alignment</span>
-            </div>
-            <div class="auth-stats">
-              <div class="auth-stat pass">
-                <span class="auth-stat-num">{{ result.authSummary.spf.alignedPass }}</span>
-                <span class="auth-stat-label">Aligned &amp; passed</span>
-              </div>
-              <div class="auth-stat warn">
-                <span class="auth-stat-num">{{ result.authSummary.spf.unalignedPass }}</span>
-                <span class="auth-stat-label">Passed, not aligned</span>
-              </div>
-              <div class="auth-stat fail">
-                <span class="auth-stat-num">{{ result.authSummary.spf.authFail }}</span>
-                <span class="auth-stat-label">Auth failed</span>
-              </div>
-              <div class="auth-stat muted">
-                <span class="auth-stat-num">{{ result.authSummary.spf.noData }}</span>
-                <span class="auth-stat-label">No data</span>
-              </div>
-            </div>
-          </div>
-          <div class="auth-card">
-            <div class="auth-card-title">
-              DKIM
-              <span v-if="result.alignmentMode" class="alignment-mode-badge">{{ result.alignmentMode.dkim }} alignment</span>
-            </div>
-            <div class="auth-stats">
-              <div class="auth-stat pass">
-                <span class="auth-stat-num">{{ result.authSummary.dkim.alignedPass }}</span>
-                <span class="auth-stat-label">Aligned &amp; passed</span>
-              </div>
-              <div class="auth-stat warn">
-                <span class="auth-stat-num">{{ result.authSummary.dkim.unalignedPass }}</span>
-                <span class="auth-stat-label">Passed, not aligned</span>
-              </div>
-              <div class="auth-stat fail">
-                <span class="auth-stat-num">{{ result.authSummary.dkim.authFail }}</span>
-                <span class="auth-stat-label">Auth failed</span>
-              </div>
-              <div class="auth-stat muted">
-                <span class="auth-stat-num">{{ result.authSummary.dkim.noData }}</span>
-                <span class="auth-stat-label">Not signed</span>
-              </div>
-            </div>
-          </div>
+        <div class="hero-text">
+          <h2 class="hero-title">{{ result.domain || 'Report Analyzed' }}</h2>
+          <p class="hero-sub">
+            {{ result.emailProvider || result.organization || 'Unknown provider' }}
+            <span v-if="result.reportDate"> · {{ new Date(result.reportDate).toLocaleDateString() }}</span>
+          </p>
         </div>
-      </div>
-
-      <!-- Policy Information -->
-      <div v-if="result.policy" class="policy-section">
-        <h4>
-          DMARC Policy
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">The DMARC policy configuration that was in effect during this reporting period.</span>
-          </span>
-        </h4>
-        <div class="policy-grid">
-          <div class="policy-item">
-            <span class="label">DMARC Policy:</span>
-            <span class="value">{{ result.policy.dmarc }}</span>
+        <div class="hero-stats">
+          <div class="hero-stat">
+            <span class="stat-num">{{ result.passRate ?? '—' }}<span v-if="result.passRate != null">%</span></span>
+            <span class="stat-label">Pass rate</span>
           </div>
-          <div class="policy-item">
-            <span class="label">SPF Alignment:</span>
-            <span class="value">{{ result.alignmentMode?.spf || result.policy.spfAlignment }}</span>
+          <div class="hero-stat-divider"></div>
+          <div class="hero-stat">
+            <span class="stat-num">{{ result.totalMessages ?? '—' }}</span>
+            <span class="stat-label">Messages</span>
           </div>
-          <div class="policy-item">
-            <span class="label">DKIM Alignment:</span>
-            <span class="value">{{ result.alignmentMode?.dkim || result.policy.dkimAlignment }}</span>
-          </div>
-          <div v-if="result.policy.sp" class="policy-item">
-            <span class="label">Subdomain Policy:</span>
-            <span class="value">{{ result.policy.sp }}</span>
-          </div>
-          <div v-if="result.policy.np" class="policy-item">
-            <span class="label">Non-Existent Subdomain Policy:</span>
-            <span class="value">{{ result.policy.np }}</span>
-          </div>
-          <div v-if="result.policy.testing" class="policy-item">
-            <span class="label">Test Mode (t=):</span>
-            <span class="value">{{ result.policy.testing }}</span>
-          </div>
-          <div v-if="result.policy.pct !== null && result.policy.pct !== undefined" class="policy-item">
-            <span class="label">Percentage (deprecated):</span>
-            <span class="value">{{ result.policy.pct }}</span>
-          </div>
-          <div v-if="result.policy.discoveryMethod" class="policy-item">
-            <span class="label">Discovery Method:</span>
-            <span class="value">{{ result.policy.discoveryMethod }}</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Report Generator / Protocol Compliance -->
-      <div v-if="result.protocol" class="protocol-section">
-        <h4>
-          Report Format
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">How well the report generator conforms to the updated DMARC standards (RFC 9989 / RFC 9990).</span>
-          </span>
-        </h4>
-        <div class="protocol-grid">
-          <div class="policy-item">
-            <span class="label">Standard:</span>
-            <span class="value">
-              <span class="proto-badge" :class="result.protocol.likelyRfc9990Generator ? 'pass' : 'muted'">
-                {{ result.protocol.likelyRfc9990Generator ? 'RFC 9990' : 'Legacy (RFC 7489)' }}
-              </span>
-            </span>
-          </div>
-          <div class="policy-item">
-            <span class="label">DKIM Selectors Reported:</span>
-            <span class="value">
-              <span class="proto-badge" :class="result.protocol.rfc9990SelectorsPresent ? 'pass' : 'warn'">
-                {{ result.protocol.rfc9990SelectorsPresent ? 'Yes' : 'Missing' }}
-              </span>
-            </span>
-          </div>
-          <div v-if="result.protocol.publishedTestMode" class="policy-item">
-            <span class="label">Published Test Mode:</span>
-            <span class="value"><span class="proto-badge warn">t=y (not enforced)</span></span>
-          </div>
-          <div v-if="result.protocol.deprecatedPublishedTags?.length" class="policy-item">
-            <span class="label">Deprecated Tags:</span>
-            <span class="value">
-              <span class="proto-badge warn">{{ result.protocol.deprecatedPublishedTags.join(', ') }}</span>
-            </span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Alignment Status -->
-      <div
-        v-if="result.domainAlignmentIssue !== undefined"
-        class="alignment-status-box"
-        :class="result.domainAlignmentIssue ? 'fail' : 'pass'"
-      >
-        <span v-if="result.domainAlignmentIssue">
-          <strong>Domain Alignment Issue Detected:</strong> Some emails failed DMARC alignment.
-        </span>
-        <span v-else>
-          <strong>No domain alignment issue detected.</strong>
-        </span>
-      </div>
-
-      <!-- Sources Table -->
-      <div v-if="result.sources?.length" class="sources-section">
-        <h4>
-          Email Sources
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">IP addresses that sent email claiming to be from your domain, with their authentication results.</span>
-          </span>
-        </h4>
-        <div class="sources-table">
-          <div class="table-header" :style="{ gridTemplateColumns: sourcesGridColumns }">
-            <span>IP Address</span>
-            <span>Domain</span>
-            <span>Count</span>
-            <span>DMARC</span>
-            <span>SPF</span>
-            <span>DKIM</span>
-            <template v-if="hasAlignmentData">
-              <span>SPF Align</span>
-              <span>DKIM Align</span>
-              <span></span>
-            </template>
-            <template v-else>
-              <span v-if="hasEnvelopeFrom">Envelope From</span>
-              <span v-if="hasSpfScope">SPF Scope</span>
-            </template>
-          </div>
-          <template v-for="src in result.sources" :key="src.ip">
-            <div
-              class="table-row"
-              :class="{ clickable: hasAlignmentData, expanded: isSourceExpanded(src.ip) }"
-              :style="{ gridTemplateColumns: sourcesGridColumns }"
-              :tabindex="hasAlignmentData ? 0 : undefined"
-              @click="hasAlignmentData && toggleSource(src.ip)"
-              @keydown.enter="hasAlignmentData && toggleSource(src.ip)"
-            >
-              <span class="ip">{{ src.ip }}</span>
-              <span class="domain" :title="src.headerFrom || ''">{{ src.headerFrom ?? '-' }}</span>
-              <span class="count">{{ src.count }}</span>
-              <span class="result" :class="src.dmarcResult === 'Pass' ? 'pass' : 'fail'">
-                {{ src.dmarcResult === 'Pass' ? 'Pass' : 'Fail' }}
-              </span>
-              <span class="result" :class="src.spfResult === 'pass' ? 'pass' : 'fail'">
-                {{ src.spfResult === 'pass' ? 'Pass' : 'Fail' }}
-              </span>
-              <span class="result" :class="src.dkimResult === 'pass' ? 'pass' : 'fail'">
-                {{ src.dkimResult === 'pass' ? 'Pass' : 'Fail' }}
-              </span>
-              <template v-if="hasAlignmentData">
-                <span class="result" :class="alignmentClass(src.spfAlignment)">
-                  {{ alignmentLabel(src.spfAlignment) }}
-                </span>
-                <span class="result" :class="alignmentClass(src.dkimAlignment)">
-                  {{ alignmentLabel(src.dkimAlignment) }}
-                </span>
-                <span class="expand-arrow">{{ isSourceExpanded(src.ip) ? '▾' : '▸' }}</span>
-              </template>
-              <template v-else>
-                <span v-if="hasEnvelopeFrom" class="envelope-from">{{ src.envelopeFrom ?? '-' }}</span>
-                <span v-if="hasSpfScope" class="spf-scope">{{ src.spfScope ?? '-' }}</span>
-              </template>
-            </div>
-
-            <!-- Expanded source detail -->
-            <div v-if="hasAlignmentData && isSourceExpanded(src.ip)" class="source-detail">
-              <div class="source-detail-grid">
-                <div v-if="src.headerFrom" class="source-detail-item">
-                  <span class="label">Header From:</span>
-                  <span class="value monospace">{{ src.headerFrom }}</span>
-                </div>
-                <div v-if="src.envelopeFrom" class="source-detail-item">
-                  <span class="label">Envelope From:</span>
-                  <span class="value monospace">{{ src.envelopeFrom }}</span>
-                </div>
-                <div v-if="src.spfDomains?.length" class="source-detail-item">
-                  <span class="label">SPF Domain(s):</span>
-                  <span class="value monospace">{{ src.spfDomains.join(', ') }}</span>
-                </div>
-                <div v-if="src.dkimDomains?.length" class="source-detail-item">
-                  <span class="label">DKIM Domain(s):</span>
-                  <span class="value monospace">{{ src.dkimDomains.join(', ') }}</span>
-                </div>
-                <div v-if="src.dkimSelectors?.length" class="source-detail-item">
-                  <span class="label">DKIM Selector(s):</span>
-                  <span class="value monospace">{{ src.dkimSelectors.join(', ') }}</span>
-                </div>
-                <div v-if="src.dispositions?.length" class="source-detail-item">
-                  <span class="label">Disposition(s):</span>
-                  <span class="value">{{ src.dispositions.join(', ') }}</span>
-                </div>
-                <div v-if="src.spfScope" class="source-detail-item">
-                  <span class="label">SPF Scope:</span>
-                  <span class="value">{{ src.spfScope }}</span>
-                </div>
-              </div>
-              <div v-if="src.failureReasons?.length" class="source-failure-reasons">
-                <span class="label">Why it failed:</span>
-                <ul>
-                  <li v-for="reason in src.failureReasons" :key="reason">{{ reason }}</li>
-                </ul>
-              </div>
+          <template v-if="result.score">
+            <div class="hero-stat-divider"></div>
+            <div class="hero-stat">
+              <span class="stat-num">{{ result.score.value }}<span class="stat-denom">/{{ result.score.outOf }}</span></span>
+              <span class="stat-label score-badge" :class="'score-' + result.score.level?.toLowerCase()">{{ result.score.level }}</span>
             </div>
           </template>
         </div>
       </div>
 
-      <!-- Detailed Records -->
-      <div v-if="result.records?.length" class="records-section">
-        <button type="button" class="collapse-toggle" @click="showRecords = !showRecords">
-          {{ showRecords ? '▾' : '▸' }} Detailed Records ({{ result.records.length }})
-        </button>
-        <div v-if="showRecords" class="records-list">
-          <div
-            v-for="(rec, i) in result.records"
-            :key="i"
-            class="record-card"
-          >
-            <div class="record-head">
-              <div class="record-id">
-                <span class="status-dot" :class="rec.dmarcResult === 'pass' ? 'pass' : 'fail'"></span>
-                <span class="ip monospace">{{ rec.sourceIp }}</span>
-                <span class="record-count">{{ rec.count }} {{ rec.count === 1 ? 'message' : 'messages' }}</span>
+      <!-- Auth breakdown -->
+      <div v-if="result.authSummary" class="card">
+        <h3 class="card-title">
+          Authentication Breakdown
+          <span class="tip" tabindex="0">?<span class="tip-pop">DMARC needs authentication AND alignment. "Passed, not aligned" means the check succeeded but for the wrong domain — it does not count toward DMARC.</span></span>
+        </h3>
+        <div class="auth-grid">
+          <div class="auth-card">
+            <div class="auth-card-head">
+              SPF
+              <span v-if="result.alignmentMode" class="align-badge">{{ result.alignmentMode.spf }} alignment</span>
+            </div>
+            <div class="auth-stats">
+              <div class="auth-stat pass">
+                <span class="as-num">{{ result.authSummary.spf.alignedPass }}</span>
+                <span class="as-label">Aligned &amp; passed</span>
               </div>
-              <div class="record-badges">
-                <span v-if="rec.likelyForwarded" class="chip">forwarded</span>
-                <span v-if="rec.disposition && rec.disposition !== 'none'" class="chip">{{ rec.disposition }}</span>
-                <span class="status-pill" :class="rec.dmarcResult === 'pass' ? 'pass' : 'fail'">
-                  {{ rec.dmarcResult === 'pass' ? 'Pass' : 'Fail' }}
-                </span>
+              <div class="auth-stat warn">
+                <span class="as-num">{{ result.authSummary.spf.unalignedPass }}</span>
+                <span class="as-label">Passed, not aligned</span>
+              </div>
+              <div class="auth-stat fail">
+                <span class="as-num">{{ result.authSummary.spf.authFail }}</span>
+                <span class="as-label">Auth failed</span>
+              </div>
+              <div class="auth-stat muted">
+                <span class="as-num">{{ result.authSummary.spf.noData }}</span>
+                <span class="as-label">No data</span>
               </div>
             </div>
-            <div class="record-auth">
-              <div class="record-auth-row">
-                <span class="auth-label">SPF</span>
-                <span class="status-dot" :class="authDotClass(rec.spf.status)"></span>
-                <span class="auth-text">{{ rec.spf.detail }}</span>
-              </div>
-              <div class="record-auth-row">
-                <span class="auth-label">DKIM</span>
-                <span class="status-dot" :class="authDotClass(rec.dkim.status)"></span>
-                <span class="auth-text">{{ rec.dkim.detail }}</span>
-              </div>
+          </div>
+          <div class="auth-card">
+            <div class="auth-card-head">
+              DKIM
+              <span v-if="result.alignmentMode" class="align-badge">{{ result.alignmentMode.dkim }} alignment</span>
             </div>
-            <div
-              v-if="rec.headerFrom || rec.envelopeFrom || rec.policyEvaluated?.reasons?.length"
-              class="record-meta"
-            >
-              <span v-if="rec.headerFrom" class="record-meta-item">
-                From <span class="monospace">{{ rec.headerFrom }}</span>
-              </span>
-              <span v-if="rec.envelopeFrom" class="record-meta-item">
-                Envelope <span class="monospace">{{ rec.envelopeFrom }}</span>
-              </span>
-              <span v-if="rec.policyEvaluated?.reasons?.length" class="record-meta-item">
-                Overrides:
-                <span v-for="(reason, ri) in rec.policyEvaluated.reasons" :key="ri">
-                  {{ formatOverride(reason) }}<template v-if="ri < rec.policyEvaluated.reasons.length - 1">, </template>
-                </span>
-              </span>
+            <div class="auth-stats">
+              <div class="auth-stat pass">
+                <span class="as-num">{{ result.authSummary.dkim.alignedPass }}</span>
+                <span class="as-label">Aligned &amp; passed</span>
+              </div>
+              <div class="auth-stat warn">
+                <span class="as-num">{{ result.authSummary.dkim.unalignedPass }}</span>
+                <span class="as-label">Passed, not aligned</span>
+              </div>
+              <div class="auth-stat fail">
+                <span class="as-num">{{ result.authSummary.dkim.authFail }}</span>
+                <span class="as-label">Auth failed</span>
+              </div>
+              <div class="auth-stat muted">
+                <span class="as-num">{{ result.authSummary.dkim.noData }}</span>
+                <span class="as-label">Not signed</span>
+              </div>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- Errors -->
-      <div v-if="result.errors?.length" class="section errors-section">
-        <h4>Errors</h4>
-        <ul>
-          <li v-for="error in result.errors" :key="error">{{ error }}</li>
-        </ul>
+      <!-- Alignment status banner -->
+      <div v-if="result.domainAlignmentIssue !== undefined"
+        class="alert"
+        :class="result.domainAlignmentIssue ? 'alert-warn' : 'alert-pass'"
+      >
+        <svg v-if="result.domainAlignmentIssue" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20 6 9 17 4 12"/></svg>
+        <span>
+          <strong>{{ result.domainAlignmentIssue ? 'Domain alignment issue detected' : 'No domain alignment issues' }}</strong>
+          <span v-if="result.domainAlignmentIssue"> — some emails failed DMARC alignment.</span>
+        </span>
       </div>
 
-      <!-- DKIM selector notices (info, not an error) -->
-      <div v-if="dkimWarnings.length" class="section dkim-notice-section">
-        <h4>Notices</h4>
-        <ul>
-          <li v-for="warning in dkimWarnings" :key="warning">{{ warning }}</li>
-        </ul>
+      <!-- Alerts -->
+      <div v-if="regularWarnings.length" class="alert alert-warn">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <ul><li v-for="w in regularWarnings" :key="w">{{ w }}</li></ul>
       </div>
 
-      <!-- Warnings -->
-      <div v-if="regularWarnings.length" class="section warnings-section">
-        <h4>Warnings</h4>
-        <ul>
-          <li v-for="warning in regularWarnings" :key="warning">{{ warning }}</li>
-        </ul>
+      <div v-if="result.errors?.length" class="alert alert-error">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+        <ul><li v-for="e in result.errors" :key="e">{{ e }}</li></ul>
       </div>
 
-      <!-- Recommendations -->
-      <div v-if="regularRecommendations.length" class="section recommendations-section">
-        <h4>Recommendations</h4>
-        <ul>
-          <li v-for="rec in regularRecommendations" :key="rec">{{ rec }}</li>
-        </ul>
+      <div v-if="regularRecommendations.length" class="alert alert-tip">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <ul><li v-for="r in regularRecommendations" :key="r">{{ r }}</li></ul>
       </div>
 
-      <!-- Forwarding (informational) -->
-      <div v-if="forwardingRecommendations.length" class="section dkim-notice-section">
-        <h4>Forwarding Detected</h4>
-        <ul>
-          <li v-for="rec in forwardingRecommendations" :key="rec">{{ rec }}</li>
-        </ul>
+      <div v-if="forwardingRecommendations.length" class="alert alert-muted">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <div><strong>Forwarding detected</strong><ul><li v-for="r in forwardingRecommendations" :key="r">{{ r }}</li></ul></div>
       </div>
 
-      <!-- Policy test mode (informational, not a failure) -->
-      <div v-if="testModeRecommendations.length" class="section test-mode-rec-section">
-        <h4>Policy Test Mode</h4>
-        <ul>
-          <li v-for="rec in testModeRecommendations" :key="rec">{{ rec }}</li>
-        </ul>
+      <div v-if="testModeRecommendations.length" class="alert alert-muted">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <div><strong>Policy test mode</strong><ul><li v-for="r in testModeRecommendations" :key="r">{{ r }}</li></ul></div>
+      </div>
+
+      <div v-if="dkimWarnings.length" class="alert alert-muted">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <div><strong>DKIM notices</strong><ul><li v-for="w in dkimWarnings" :key="w">{{ w }}</li></ul></div>
+      </div>
+
+      <!-- Email sources table -->
+      <div v-if="result.sources?.length" class="card">
+        <h3 class="card-title">
+          Email Sources
+          <span class="tip" tabindex="0">?<span class="tip-pop">IP addresses that sent email claiming to be from your domain, with their authentication results.</span></span>
+        </h3>
+        <div class="sources-wrap">
+          <div class="sources-table">
+            <div class="sources-head" :style="{ gridTemplateColumns: sourcesGridColumns }">
+              <span>IP Address</span>
+              <span>Domain</span>
+              <span>Count</span>
+              <span>DMARC</span>
+              <span>SPF</span>
+              <span>DKIM</span>
+              <template v-if="hasAlignmentData">
+                <span>SPF Align</span>
+                <span>DKIM Align</span>
+                <span></span>
+              </template>
+              <template v-else>
+                <span v-if="hasEnvelopeFrom">Envelope From</span>
+                <span v-if="hasSpfScope">SPF Scope</span>
+              </template>
+            </div>
+            <template v-for="src in result.sources" :key="src.ip">
+              <div
+                class="sources-row"
+                :class="{ clickable: hasAlignmentData, expanded: isSourceExpanded(src.ip) }"
+                :style="{ gridTemplateColumns: sourcesGridColumns }"
+                :tabindex="hasAlignmentData ? 0 : undefined"
+                @click="hasAlignmentData && toggleSource(src.ip)"
+                @keydown.enter="hasAlignmentData && toggleSource(src.ip)"
+              >
+                <span class="cell-mono">{{ src.ip }}</span>
+                <span class="cell-mono cell-ellipsis" :title="src.headerFrom || ''">{{ src.headerFrom ?? '—' }}</span>
+                <span class="cell-bold">{{ src.count }}</span>
+                <span class="cell-result" :class="src.dmarcResult === 'Pass' ? 'pass' : 'fail'">{{ src.dmarcResult === 'Pass' ? 'Pass' : 'Fail' }}</span>
+                <span class="cell-result" :class="src.spfResult === 'pass' ? 'pass' : 'fail'">{{ src.spfResult === 'pass' ? 'Pass' : 'Fail' }}</span>
+                <span class="cell-result" :class="src.dkimResult === 'pass' ? 'pass' : 'fail'">{{ src.dkimResult === 'pass' ? 'Pass' : 'Fail' }}</span>
+                <template v-if="hasAlignmentData">
+                  <span class="cell-result" :class="alignmentClass(src.spfAlignment)">{{ alignmentLabel(src.spfAlignment) }}</span>
+                  <span class="cell-result" :class="alignmentClass(src.dkimAlignment)">{{ alignmentLabel(src.dkimAlignment) }}</span>
+                  <span class="cell-chevron">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"
+                      :style="{ transform: isSourceExpanded(src.ip) ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }">
+                      <polyline points="6 9 12 15 18 9"/>
+                    </svg>
+                  </span>
+                </template>
+                <template v-else>
+                  <span v-if="hasEnvelopeFrom" class="cell-mono">{{ src.envelopeFrom ?? '—' }}</span>
+                  <span v-if="hasSpfScope" class="cell-muted">{{ src.spfScope ?? '—' }}</span>
+                </template>
+              </div>
+
+              <div v-if="hasAlignmentData && isSourceExpanded(src.ip)" class="source-detail">
+                <div class="source-detail-grid">
+                  <div v-if="src.headerFrom" class="sd-item"><span class="sd-label">Header From</span><span class="sd-value mono">{{ src.headerFrom }}</span></div>
+                  <div v-if="src.envelopeFrom" class="sd-item"><span class="sd-label">Envelope From</span><span class="sd-value mono">{{ src.envelopeFrom }}</span></div>
+                  <div v-if="src.spfDomains?.length" class="sd-item"><span class="sd-label">SPF Domain(s)</span><span class="sd-value mono">{{ src.spfDomains.join(', ') }}</span></div>
+                  <div v-if="src.dkimDomains?.length" class="sd-item"><span class="sd-label">DKIM Domain(s)</span><span class="sd-value mono">{{ src.dkimDomains.join(', ') }}</span></div>
+                  <div v-if="src.dkimSelectors?.length" class="sd-item"><span class="sd-label">DKIM Selector(s)</span><span class="sd-value mono">{{ src.dkimSelectors.join(', ') }}</span></div>
+                  <div v-if="src.dispositions?.length" class="sd-item"><span class="sd-label">Disposition(s)</span><span class="sd-value">{{ src.dispositions.join(', ') }}</span></div>
+                  <div v-if="src.spfScope" class="sd-item"><span class="sd-label">SPF Scope</span><span class="sd-value">{{ src.spfScope }}</span></div>
+                </div>
+                <div v-if="src.failureReasons?.length" class="sd-failures">
+                  <span class="sd-fail-label">Why it failed</span>
+                  <ul><li v-for="reason in src.failureReasons" :key="reason">{{ reason }}</li></ul>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <!-- Expert disclosures -->
+      <div class="disclosures">
+
+        <!-- Report metadata -->
+        <details class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">Report details</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <dl class="meta-list">
+              <div class="meta-row"><dt>Provider</dt><dd>{{ result.emailProvider || result.organization || '—' }}</dd></div>
+              <div class="meta-row"><dt>Domain</dt><dd>{{ result.domain || '—' }}</dd></div>
+              <div class="meta-row"><dt>Report ID</dt><dd class="mono">{{ result.reportId || '—' }}</dd></div>
+              <div class="meta-row"><dt>Date range</dt><dd>{{ formatDateRange(result.dateRange) }}</dd></div>
+              <div v-if="result.version" class="meta-row"><dt>Version</dt><dd>{{ result.version }}</dd></div>
+              <div v-if="result.generator" class="meta-row"><dt>Generator</dt><dd>{{ result.generator }}</dd></div>
+              <div v-if="result.likelyForwardedCount" class="meta-row">
+                <dt>Likely forwarded</dt><dd>{{ result.likelyForwardedCount }}</dd>
+              </div>
+            </dl>
+          </div>
+        </details>
+
+        <!-- Policy -->
+        <details v-if="result.policy" class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">DMARC policy in effect</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <dl class="meta-list">
+              <div class="meta-row"><dt>Policy</dt><dd>{{ result.policy.dmarc }}</dd></div>
+              <div class="meta-row"><dt>SPF alignment</dt><dd>{{ result.alignmentMode?.spf || result.policy.spfAlignment }}</dd></div>
+              <div class="meta-row"><dt>DKIM alignment</dt><dd>{{ result.alignmentMode?.dkim || result.policy.dkimAlignment }}</dd></div>
+              <div v-if="result.policy.sp" class="meta-row"><dt>Subdomain policy</dt><dd>{{ result.policy.sp }}</dd></div>
+              <div v-if="result.policy.np" class="meta-row"><dt>Non-existent subdomain</dt><dd>{{ result.policy.np }}</dd></div>
+              <div v-if="result.policy.testing" class="meta-row"><dt>Test mode</dt><dd>{{ result.policy.testing }}</dd></div>
+              <div v-if="result.policy.pct != null" class="meta-row"><dt>Percentage (deprecated)</dt><dd>{{ result.policy.pct }}</dd></div>
+              <div v-if="result.policy.discoveryMethod" class="meta-row"><dt>Discovery method</dt><dd>{{ result.policy.discoveryMethod }}</dd></div>
+            </dl>
+          </div>
+        </details>
+
+        <!-- Report format / protocol -->
+        <details v-if="result.protocol" class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">Report format compliance</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <dl class="meta-list">
+              <div class="meta-row">
+                <dt>Standard</dt>
+                <dd><span class="proto-badge" :class="result.protocol.likelyRfc9990Generator ? 'pass' : 'muted'">{{ result.protocol.likelyRfc9990Generator ? 'RFC 9990' : 'Legacy (RFC 7489)' }}</span></dd>
+              </div>
+              <div class="meta-row">
+                <dt>DKIM selectors reported</dt>
+                <dd><span class="proto-badge" :class="result.protocol.rfc9990SelectorsPresent ? 'pass' : 'warn'">{{ result.protocol.rfc9990SelectorsPresent ? 'Yes' : 'Missing' }}</span></dd>
+              </div>
+              <div v-if="result.protocol.publishedTestMode" class="meta-row">
+                <dt>Published test mode</dt>
+                <dd><span class="proto-badge warn">t=y (not enforced)</span></dd>
+              </div>
+              <div v-if="result.protocol.deprecatedPublishedTags?.length" class="meta-row">
+                <dt>Deprecated tags</dt>
+                <dd><span class="proto-badge warn">{{ result.protocol.deprecatedPublishedTags.join(', ') }}</span></dd>
+              </div>
+            </dl>
+          </div>
+        </details>
+
+        <!-- Detailed records -->
+        <details v-if="result.records?.length" class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">Detailed records ({{ result.records.length }})</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <div class="records-list">
+              <div v-for="(rec, i) in result.records" :key="i" class="record-card">
+                <div class="record-head">
+                  <div class="record-id">
+                    <span class="status-dot" :class="rec.dmarcResult === 'pass' ? 'pass' : 'fail'"></span>
+                    <span class="mono record-ip">{{ rec.sourceIp }}</span>
+                    <span class="record-count">{{ rec.count }} {{ rec.count === 1 ? 'message' : 'messages' }}</span>
+                  </div>
+                  <div class="record-badges">
+                    <span v-if="rec.likelyForwarded" class="chip">forwarded</span>
+                    <span v-if="rec.disposition && rec.disposition !== 'none'" class="chip">{{ rec.disposition }}</span>
+                    <span class="status-pill" :class="rec.dmarcResult === 'pass' ? 'pass' : 'fail'">
+                      {{ rec.dmarcResult === 'pass' ? 'Pass' : 'Fail' }}
+                    </span>
+                  </div>
+                </div>
+                <div class="record-auth">
+                  <div class="record-auth-row">
+                    <span class="auth-label">SPF</span>
+                    <span class="status-dot" :class="authDotClass(rec.spf.status)"></span>
+                    <span class="auth-text">{{ rec.spf.detail }}</span>
+                  </div>
+                  <div class="record-auth-row">
+                    <span class="auth-label">DKIM</span>
+                    <span class="status-dot" :class="authDotClass(rec.dkim.status)"></span>
+                    <span class="auth-text">{{ rec.dkim.detail }}</span>
+                  </div>
+                </div>
+                <div v-if="rec.headerFrom || rec.envelopeFrom || rec.policyEvaluated?.reasons?.length" class="record-meta">
+                  <span v-if="rec.headerFrom" class="record-meta-item">From <span class="mono">{{ rec.headerFrom }}</span></span>
+                  <span v-if="rec.envelopeFrom" class="record-meta-item">Envelope <span class="mono">{{ rec.envelopeFrom }}</span></span>
+                  <span v-if="rec.policyEvaluated?.reasons?.length" class="record-meta-item">
+                    Overrides: <span v-for="(reason, ri) in rec.policyEvaluated.reasons" :key="ri">{{ formatOverride(reason) }}<template v-if="ri < rec.policyEvaluated.reasons.length - 1">, </template></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </details>
+
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-/* Base Layout */
 .dmarc-analyzer {
-  max-width: 800px;
+  max-width: 820px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 1rem 3rem;
 }
 
-.tool-form {
-  margin: 2rem 0;
+/* ── Upload card ── */
+.upload-card {
+  position: relative;
+  margin: 2rem 0 1.5rem;
   padding: 1.5rem;
   background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 12px;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 14px;
+  transition: border-color 0.15s;
 }
 
-/* Form Fields Container - Only this area handles drag */
-.form-fields-container {
-  position: relative;
-  border-radius: 8px;
-  transition: all 0.2s ease;
-  margin-bottom: 1.5rem;
+.upload-card.drag-active {
+  border-color: var(--vp-c-brand);
+  background: hsla(197, 87%, 50%, 0.03);
 }
 
-.form-fields-container.drag-hover {
-  background: rgba(19, 176, 238, 0.02);
-  border-radius: 8px;
-}
-
-.drag-overlay-fields {
+.drag-overlay {
   position: absolute;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(19, 176, 238, 0.08);
-  backdrop-filter: blur(4px);
-  z-index: 100;
+  background: hsla(197, 87%, 50%, 0.08);
+  backdrop-filter: blur(3px);
+  border-radius: 12px;
+  z-index: 10;
   pointer-events: none;
-  border-radius: 8px;
-  border: 2px dashed rgba(19, 176, 238, 0.3);
-  animation: fadeInSubtle 0.2s ease-out;
+  border: 2px dashed hsla(197, 87%, 50%, 0.4);
 }
 
 .drag-content {
-  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 2rem;
+  background: var(--vp-c-bg, #fff);
+  border-radius: 10px;
+  border: 1px solid hsla(197, 87%, 50%, 0.2);
   color: var(--vp-c-brand);
-  padding: 1.5rem;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(19, 176, 238, 0.2);
-  box-shadow: 0 4px 16px rgba(19, 176, 238, 0.1);
-  animation: pulse-subtle 2s ease-in-out infinite;
-}
-
-.drag-icon {
-  font-size: 2rem;
-  margin-bottom: 0.5rem;
-  display: block;
-  opacity: 0.8;
-}
-
-.drag-text {
-  font-size: 1.1rem;
   font-weight: 600;
-  display: block;
-  margin-bottom: 0.25rem;
-  color: var(--vp-c-brand);
-}
-
-.drag-subtext {
-  font-size: 0.875rem;
-  opacity: 0.7;
-  font-weight: 500;
-  color: var(--vp-c-text-2, #6b7280);
-}
-
-/* Subtle Animations */
-@keyframes fadeInSubtle {
-  from {
-    opacity: 0;
-    transform: scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-@keyframes pulse-subtle {
-  0%, 100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: scale(1.02);
-    opacity: 0.95;
-  }
+  font-size: 1rem;
 }
 
 .form-group {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
 }
 
 .form-group label {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4rem;
   font-weight: 600;
+  font-size: 0.875rem;
   color: var(--vp-c-text-1, #374151);
-  font-size: 0.9rem;
+  letter-spacing: 0.01em;
 }
 
-.form-group input,
 .form-group textarea {
   width: 100%;
-  padding: 0.875rem 1rem;
-  border: 2px solid var(--vp-c-border, #e5e7eb);
+  padding: 0.75rem 1rem;
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
   border-radius: 8px;
-  font-size: 1rem;
-  transition: border-color 0.2s ease;
-  box-sizing: border-box;
-  background: var(--vp-c-bg, #ffffff);
+  font-size: 0.875rem;
+  font-family: var(--vp-font-family-mono, monospace);
+  resize: vertical;
+  line-height: 1.5;
+  background: var(--vp-c-bg, #fff);
   color: var(--vp-c-text-1, #374151);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  box-sizing: border-box;
 }
 
-.form-group input:focus,
 .form-group textarea:focus {
   outline: none;
   border-color: var(--vp-c-brand);
-  box-shadow: 0 0 0 3px rgba(19, 176, 238, 0.1);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
 }
 
-.form-group input:disabled,
 .form-group textarea:disabled {
-  background: var(--vp-c-bg-mute, #f1f5f9);
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
-/* File Upload Area - Using Brand Colors */
-.file-upload-area {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-top: 0.5rem;
-  min-height: 44px;
-  padding: 0.5rem;
-  border-radius: 8px;
-  transition: all 0.2s ease;
-}
+/* File zone */
+.file-zone { margin-top: 0.25rem; }
 
-.file-upload-label {
+.file-label {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
   cursor: pointer;
-  padding: 0.75rem 1.5rem;
+  padding: 0.875rem 1rem;
+  border: 1.5px dashed var(--vp-c-border, #d1d5db);
   border-radius: 8px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 2px dashed var(--vp-c-border, #e5e7eb);
-  color: var(--vp-c-text-1, #374151);
-  font-size: 0.95rem;
-  text-align: center;
-  user-select: none;
-  transition: all 0.2s ease;
-  flex: 1;
+  cursor: pointer;
+  font-size: 0.875rem;
   font-weight: 500;
+  color: var(--vp-c-text-2, #6b7280);
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
 }
 
-.file-upload-label:hover:not(.disabled) {
+.file-label:hover:not(.disabled) {
   border-color: var(--vp-c-brand);
-  background: rgba(19, 176, 238, 0.05);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  color: var(--vp-c-brand);
+  background: hsla(197, 87%, 50%, 0.04);
 }
 
-.file-upload-label.disabled {
-  opacity: 0.6;
+.file-label.disabled {
+  opacity: 0.45;
   cursor: not-allowed;
-  pointer-events: none;
 }
 
-.file-name-row {
+.file-selected {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  min-width: 0;
-  flex: 1;
-  padding: 0.5rem 1rem;
-  background: var(--vp-c-bg, #ffffff);
-  border: 2px solid var(--vp-c-brand);
+  gap: 0.625rem;
+  padding: 0.625rem 0.875rem;
+  border: 1.5px solid var(--vp-c-brand);
   border-radius: 8px;
+  background: hsla(197, 87%, 50%, 0.05);
+  color: var(--vp-c-brand);
 }
 
 .file-name {
   flex: 1;
-  min-width: 0;
-  font-weight: 600;
-  color: var(--vp-c-brand);
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-.remove-file-btn {
-  background: var(--vp-c-danger-1, #dc3545);
-  color: white;
-  border: none;
-  padding: 0.4rem 1rem;
-  border-radius: 6px;
-  cursor: pointer;
   font-size: 0.875rem;
-  font-weight: 500;
-  white-space: nowrap;
-  transition: all 0.2s ease;
-  flex-shrink: 0;
-}
-
-.remove-file-btn:hover:not(:disabled) {
-  background: var(--vp-c-danger-2, #c82333);
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(220, 53, 69, 0.3);
-}
-
-.remove-file-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-/* Button */
-.check-btn {
-  background: var(--vp-c-brand);
-  color: #ffffff;
-  padding: 0.875rem 2rem;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 1rem;
   font-weight: 600;
-  transition: all 0.2s ease;
-  width: 100%;
-  box-shadow: 0 2px 4px rgba(19, 176, 238, 0.2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.check-btn:hover:not(:disabled) {
-  background: var(--vp-c-brand-light);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(19, 176, 238, 0.25);
-}
-
-.check-btn:active:not(:disabled) {
-  background: var(--vp-c-brand-dark);
-  transform: translateY(0);
-}
-
-.check-btn:disabled {
-  background: var(--vp-c-bg-mute, #9ca3af);
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-.btn-loading {
+.file-remove {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
   justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--vp-c-text-2, #6b7280);
+  border-radius: 4px;
+  flex-shrink: 0;
+  transition: color 0.15s, background 0.15s;
 }
 
-.loading-spinner {
-  width: 12px;
-  height: 12px;
-  border: 1.5px solid rgba(255, 255, 255, 0.3);
-  border-top: 1.5px solid #ffffff;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
+.file-remove:hover { color: #dc2626; background: rgba(220,38,38,0.08); }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-
-/* Error Section */
-.error-section {
-  background: var(--vp-danger-soft, #f8d7da);
-  color: var(--vp-c-danger-1, #721c24);
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
-  border: 1px solid var(--vp-c-danger-2, #f5c6cb);
-}
-
-.error-message {
-  margin: 0;
-  font-weight: 500;
-}
-
-/* Results Section */
-.result-section {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.result-section h3 {
-  margin: 0 0 1.5rem 0;
-  color: var(--vp-c-text-1, #1a202c);
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-/* Info tip styles */
-.info-tip {
-  display: inline-block;
-  margin-left: .3rem;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1rem;
-  text-align: center;
-  border-radius: 50%;
+/* Submit */
+.submit-btn {
+  width: 100%;
+  margin-top: 1rem;
+  padding: 0.75rem 2rem;
   background: var(--vp-c-brand);
   color: #fff;
-  font-size: .675rem;
-  cursor: help;
-  position: relative;
-  vertical-align: middle;
-}
-
-.info-tip-pop {
-  opacity: 0;
-  pointer-events: none;
-  position: absolute;
-  left: 50%;
-  top: calc(100% + 8px);
-  transform: translateX(-50%);
-  width: max-content;
-  max-width: min(300px, 90vw);
-  padding: .8rem 1rem;
-  border-radius: 8px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  box-shadow: 0 8px 24px rgba(0,0,0,.12);
-  color: var(--vp-c-text-1, #374151);
-  font-size: .825rem;
-  line-height: 1.5;
-  z-index: 1000;
-  transition: opacity .2s ease, transform .2s ease;
-  transform: translateX(-50%) translateY(-4px);
-  word-wrap: break-word;
-  hyphens: auto;
-}
-
-.info-tip-pop::before {
-  content: '';
-  position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 12px;
-  height: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  border-bottom: none;
-  border-right: none;
-  transform: translateX(-50%) rotate(45deg);
-}
-
-.info-tip:hover .info-tip-pop,
-.info-tip:focus .info-tip-pop {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
-
-.info-tip:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:last-child .info-tip-pop {
-  left: auto;
-  right: 0;
-  transform: translateX(0);
-}
-
-.info-tip:nth-last-child(-n+2) .info-tip-pop::before,
-.info-tip:last-child .info-tip-pop::before {
-  left: auto;
-  right: 1rem;
-  transform: translateX(0) rotate(45deg);
-}
-
-.info-tip:hover:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:focus:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:hover:last-child .info-tip-pop,
-.info-tip:focus:last-child .info-tip-pop {
-  transform: translateX(0) translateY(0);
-}
-
-/* Info Section */
-.info-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.info-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
+  font-size: 0.9rem;
   font-weight: 600;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s, box-shadow 0.15s;
+  box-shadow: 0 1px 4px hsla(197, 87%, 50%, 0.3);
 }
 
-.summary-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+.submit-btn:hover:not(:disabled) {
+  background: var(--vp-c-brand-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px hsla(197, 87%, 50%, 0.35);
 }
 
-.summary-item {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.75rem;
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 6px;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  min-width: 0;
-  overflow: visible;
+.submit-btn:disabled { opacity: 0.5; cursor: not-allowed; box-shadow: none; }
+
+.btn-loading { display: flex; align-items: center; justify-content: center; gap: 0.5rem; }
+
+.spinner {
+  display: inline-block;
+  width: 14px; height: 14px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
 }
 
-.summary-item .label {
-  color: var(--vp-c-text-2, #6b7280);
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Error */
+.error-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid rgba(220,38,38,0.2);
+  border-radius: 8px;
   font-size: 0.875rem;
   font-weight: 500;
-  flex-shrink: 0;
+  margin-bottom: 1rem;
 }
 
-.summary-item .value {
-  color: var(--vp-c-text-1, #374151);
-  font-weight: 600;
-  font-size: 1rem;
-  word-break: break-all;
-  overflow-wrap: break-word;
-  line-height: 1.4;
-  min-width: 0;
+/* Results */
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+/* Hero */
+.hero {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
   flex-wrap: wrap;
 }
 
-.summary-item .value.monospace {
-  font-family: var(--vp-font-family-mono, 'Courier New', monospace);
-  font-size: 0.875rem;
-  letter-spacing: -0.25px;
+.hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.06) 0%, hsla(197,87%,50%,0.04) 100%); border-color: rgba(22,163,74,0.2); }
+.hero-warn { background: rgba(217,119,6,0.05); border-color: rgba(217,119,6,0.2); }
+.hero-fail { background: rgba(220,38,38,0.04); border-color: rgba(220,38,38,0.18); }
+
+.hero-icon {
+  width: 52px; height: 52px;
+  border-radius: 13px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
 }
 
-/* Policy Section */
-.policy-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
+.icon-pass { background: rgba(22,163,74,0.12); color: #16a34a; border: 1px solid rgba(22,163,74,0.2); }
+.icon-warn { background: rgba(217,119,6,0.12);  color: #d97706; border: 1px solid rgba(217,119,6,0.2); }
+.icon-fail { background: rgba(220,38,38,0.1);   color: #dc2626; border: 1px solid rgba(220,38,38,0.15); }
 
-.policy-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
+.hero-text { flex: 1; min-width: 0; }
+
+.hero-title {
+  margin: 0 0 0.2rem;
   font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.policy-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-}
-
-.policy-item {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.75rem;
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 6px;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  overflow: visible;
-}
-
-.policy-item .label {
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.policy-item .value {
-  color: var(--vp-c-text-1, #374151);
-  font-weight: 600;
-  font-size: 1rem;
-}
-
-/* Alignment Status */
-.alignment-status-box {
-  margin: 1.5rem 0;
-  padding: 1rem 1.5rem;
-  border-radius: 8px;
-  font-weight: 600;
-  font-size: 1.08rem;
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.04);
-}
-
-.alignment-status-box.pass {
-  color: #217b2d;
-  background: #ebf7ed;
-  border: 1px solid rgba(34, 187, 51, 0.2);
-}
-
-.alignment-status-box.fail {
-  color: #b91c1c;
-  background: #fbeaea;
-  border: 1px solid rgba(234, 67, 53, 0.2);
-}
-
-/* Sources Table */
-.sources-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.sources-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.sources-table {
-  overflow-x: auto;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 8px;
-}
-
-.table-header,
-.table-row {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  align-items: center;
-  border-bottom: 1px solid var(--vp-c-border-soft, #eee);
-}
-
-.table-header {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  font-weight: 600;
-  color: var(--vp-c-text-1, #374151);
-  font-size: 0.875rem;
-}
-
-.table-row:last-child {
-  border-bottom: none;
-}
-
-.table-row:hover {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-}
-
-.table-row .ip {
-  font-family: var(--vp-font-family-mono, monospace);
-  font-size: 0.875rem;
-  color: var(--vp-c-text-1, #374151);
-}
-
-.table-row .domain {
-  font-family: var(--vp-font-family-mono, monospace);
-  font-size: 0.875rem;
-  color: var(--vp-c-text-1, #374151);
+  font-weight: 700;
+  color: var(--vp-c-text-1, #111827);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  min-width: 0;
 }
 
-.table-row .count {
-  font-weight: 600;
-  color: var(--vp-c-text-1, #374151);
-}
-
-.table-row .result.pass {
-  color: #22bb33;
-  font-weight: 600;
-}
-
-.table-row .result.fail {
-  color: #ea4335;
-  font-weight: 600;
-}
-
-/* Result Sections */
-.section {
-  margin-top: 1.5rem;
-  padding: 1.25rem;
-  border-radius: 8px;
-}
-
-.section h4 {
-  margin: 0 0 1rem 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.section ul {
+.hero-sub {
   margin: 0;
-  padding-left: 1.5rem;
-}
-
-.section li {
-  margin: 0.5rem 0;
-  line-height: 1.5;
-}
-
-.errors-section {
-  background: var(--vp-danger-soft, #fef2f2);
-  border: 1px solid rgba(220, 53, 69, 0.15);
-}
-
-.errors-section h4 {
-  color: var(--vp-c-danger-1, #b91c1c);
-}
-
-.warnings-section {
-  background: var(--vp-warning-soft, #fffbf0);
-  border: 1px solid rgba(214, 158, 46, 0.2);
-}
-
-.warnings-section h4 {
-  color: var(--vp-c-warning-1, #d69e2e);
-}
-
-.recommendations-section {
-  background: var(--vp-tip-soft, #f0f9ff);
-  border: 1px solid rgba(23, 162, 184, 0.18);
-}
-
-.recommendations-section h4 {
-  color: var(--vp-c-tip-1, #17a2b8);
-}
-
-.dkim-notice-section {
-  background: #f0f9ff;
-  border: 1px solid rgba(59, 130, 246, 0.18);
-}
-
-.dkim-notice-section h4 {
-  color: #1d4ed8;
-}
-
-.test-mode-rec-section {
-  background: #f0f9ff;
-  border: 1px solid rgba(59, 130, 246, 0.18);
-}
-
-.test-mode-rec-section h4 {
-  color: #1d4ed8;
-}
-
-.table-row .envelope-from {
-  font-family: var(--vp-font-family-mono, monospace);
-  font-size: 0.875rem;
-  color: var(--vp-c-text-2, #6b7280);
-  word-break: break-all;
-}
-
-.table-row .spf-scope {
-  font-size: 0.875rem;
+  font-size: 0.8rem;
   color: var(--vp-c-text-2, #6b7280);
 }
 
-/* ---- Auth Summary ---- */
-.auth-summary-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
+.hero-stats {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-shrink: 0;
 }
 
-.auth-summary-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
+.hero-stat { display: flex; flex-direction: column; align-items: center; text-align: center; }
+
+.stat-num {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: var(--vp-c-text-1, #111827);
+  line-height: 1;
+}
+
+.stat-denom { font-size: 0.9rem; font-weight: 500; color: var(--vp-c-text-3, #9ca3af); }
+
+.stat-label {
+  font-size: 0.7rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-text-2, #6b7280);
+  margin-top: 0.15rem;
 }
 
-.auth-summary-grid {
+.score-badge {
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+}
+
+.score-strong, .score-excellent { background: rgba(22,163,74,0.12); color: #15803d; }
+.score-good,   .score-medium   { background: rgba(217,119,6,0.12);  color: #b45309; }
+.score-poor,   .score-weak     { background: rgba(220,38,38,0.1);   color: #dc2626; }
+
+.hero-stat-divider {
+  width: 1px; height: 2rem;
+  background: var(--vp-c-border, #e5e7eb);
+}
+
+/* Card */
+.card {
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+}
+
+.card-title {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-text-1, #374151);
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+/* Alerts */
+.alert {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.875rem 1.125rem;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+.alert > svg { flex-shrink: 0; margin-top: 0.1rem; }
+.alert strong { display: block; font-weight: 700; margin-bottom: 0.2rem; }
+.alert ul { margin: 0; padding-left: 1.1rem; }
+.alert li + li { margin-top: 0.2rem; }
+
+.alert-pass  { background: rgba(22,163,74,0.06);   border-color: rgba(22,163,74,0.2);  color: var(--vp-c-text-1); }
+.alert-pass  > svg { color: #16a34a; }
+.alert-warn  { background: rgba(217,119,6,0.06);   border-color: rgba(217,119,6,0.2);  color: var(--vp-c-text-1); }
+.alert-warn  > svg { color: #d97706; }
+.alert-error { background: rgba(220,38,38,0.05);   border-color: rgba(220,38,38,0.18); color: #991b1b; }
+.alert-error > svg { color: #dc2626; }
+.alert-tip   { background: hsla(197,87%,50%,0.05); border-color: hsla(197,87%,50%,0.2); color: var(--vp-c-text-1); }
+.alert-tip   > svg { color: var(--vp-c-brand-dark, #0891b2); }
+.alert-muted { background: var(--vp-c-bg-soft, #f9fafb); border-color: var(--vp-c-border, #e5e7eb); color: var(--vp-c-text-2, #6b7280); }
+.alert-muted > svg { color: var(--vp-c-text-3, #9ca3af); }
+
+/* Auth breakdown */
+.auth-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .auth-card {
   padding: 1rem;
   background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 8px;
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+  border-radius: 10px;
 }
 
-.auth-card-title {
+.auth-card-head {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 0.9rem;
   margin-bottom: 0.75rem;
   display: flex;
   align-items: center;
@@ -1575,21 +981,21 @@ onMounted(async () => {
   color: var(--vp-c-text-1, #374151);
 }
 
-.alignment-mode-badge {
-  font-size: 0.7rem;
-  font-weight: 600;
+.align-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.03em;
-  padding: 0.15rem 0.5rem;
+  letter-spacing: 0.04em;
+  padding: 0.15rem 0.45rem;
   border-radius: 999px;
-  background: rgba(19, 176, 238, 0.12);
+  background: hsla(197, 87%, 50%, 0.12);
   color: var(--vp-c-brand);
 }
 
 .auth-stats {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0.5rem;
+  gap: 0.375rem;
 }
 
 .auth-stat {
@@ -1597,175 +1003,162 @@ onMounted(async () => {
   flex-direction: column;
   align-items: center;
   padding: 0.5rem 0.25rem;
-  border-radius: 6px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #eee);
+  border-radius: 7px;
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
   text-align: center;
 }
 
-.auth-stat-num {
-  font-size: 1.25rem;
-  font-weight: 700;
-  line-height: 1.2;
-}
+.as-num { font-size: 1.2rem; font-weight: 700; line-height: 1.2; }
+.as-label { font-size: 0.65rem; color: var(--vp-c-text-2, #6b7280); line-height: 1.3; margin-top: 0.15rem; }
 
-.auth-stat-label {
-  font-size: 0.7rem;
-  color: var(--vp-c-text-2, #6b7280);
-  line-height: 1.3;
-}
+.auth-stat.pass .as-num { color: #16a34a; }
+.auth-stat.warn .as-num { color: #d97706; }
+.auth-stat.fail .as-num { color: #dc2626; }
+.auth-stat.muted .as-num { color: var(--vp-c-text-2, #6b7280); }
 
-.auth-stat.pass .auth-stat-num { color: #22bb33; }
-.auth-stat.warn .auth-stat-num { color: #d69e2e; }
-.auth-stat.fail .auth-stat-num { color: #ea4335; }
-.auth-stat.muted .auth-stat-num { color: var(--vp-c-text-2, #6b7280); }
+/* Sources table */
+.sources-wrap { overflow-x: auto; border-radius: 8px; border: 1px solid var(--vp-c-border, #e5e7eb); }
 
-/* ---- Protocol Section ---- */
-.protocol-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
+.sources-table { min-width: 600px; }
 
-.protocol-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.protocol-grid {
+.sources-head {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-}
-
-.proto-badge {
-  display: inline-block;
-  padding: 0.15rem 0.6rem;
-  border-radius: 999px;
-  font-size: 0.78rem;
-  font-weight: 600;
-}
-
-.proto-badge.pass { background: #ebf7ed; color: #217b2d; }
-.proto-badge.warn { background: #fff8e6; color: #b45309; }
-.proto-badge.fail { background: #fbeaea; color: #b91c1c; }
-.proto-badge.muted { background: var(--vp-c-bg-mute, #f1f5f9); color: var(--vp-c-text-2, #6b7280); }
-
-/* ---- Alignment cells ---- */
-.table-row .result.warn {
-  color: #d69e2e;
-  font-weight: 600;
-}
-
-.table-row .result.muted {
-  color: var(--vp-c-text-2, #9ca3af);
-  font-weight: 500;
-}
-
-.table-row.clickable {
-  cursor: pointer;
-}
-
-.table-row.expanded {
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
   background: var(--vp-c-bg-soft, #f8f9fa);
-}
-
-.expand-arrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
   color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.8rem;
-  text-align: right;
+  border-bottom: 1px solid var(--vp-c-border, #e5e7eb);
 }
 
-/* ---- Expanded source detail ---- */
+.sources-row {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  align-items: center;
+  border-bottom: 1px solid var(--vp-c-border-soft, #f1f5f9);
+  font-size: 0.85rem;
+  transition: background 0.1s;
+}
+
+.sources-row:last-child { border-bottom: none; }
+.sources-row:hover { background: var(--vp-c-bg-soft, #f8f9fa); }
+.sources-row.clickable { cursor: pointer; }
+.sources-row.expanded { background: var(--vp-c-bg-soft, #f8f9fa); }
+
+.cell-mono    { font-family: monospace; font-size: 0.8rem; color: var(--vp-c-text-1); }
+.cell-ellipsis { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.cell-bold    { font-weight: 600; color: var(--vp-c-text-1); }
+.cell-muted   { color: var(--vp-c-text-2, #6b7280); font-size: 0.8rem; }
+.cell-chevron { display: flex; align-items: center; color: var(--vp-c-text-3, #9ca3af); }
+
+.cell-result { font-weight: 600; font-size: 0.8rem; }
+.cell-result.pass    { color: #16a34a; }
+.cell-result.fail    { color: #dc2626; }
+.cell-result.warn    { color: #d97706; }
+.cell-result.muted   { color: var(--vp-c-text-3, #9ca3af); font-weight: 400; }
+.cell-result.aligned { color: #16a34a; }
+.cell-result.unaligned { color: #dc2626; }
+.cell-result.mixed   { color: #d97706; }
+.cell-result.no_data { color: var(--vp-c-text-3, #9ca3af); font-weight: 400; }
+
+/* Source detail expand */
 .source-detail {
-  padding: 0.75rem 1.25rem 1rem;
+  padding: 0.875rem 1rem;
   background: var(--vp-c-bg-soft, #f8f9fa);
-  border-bottom: 1px solid var(--vp-c-border-soft, #eee);
-  font-size: 0.875rem;
+  border-bottom: 1px solid var(--vp-c-border-soft, #e5e7eb);
 }
 
 .source-detail-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.5rem 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.5rem 1.25rem;
   margin-bottom: 0.5rem;
 }
 
-.source-detail-item .label {
-  color: var(--vp-c-text-2, #6b7280);
-  font-weight: 500;
-  margin-right: 0.4rem;
+.sd-item { display: flex; flex-direction: column; gap: 0.1rem; }
+.sd-label { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--vp-c-text-2, #6b7280); }
+.sd-value { font-size: 0.825rem; color: var(--vp-c-text-1); word-break: break-all; }
+.sd-value.mono { font-family: monospace; }
+
+.sd-failures { margin-top: 0.5rem; }
+.sd-fail-label { font-size: 0.75rem; font-weight: 700; color: #dc2626; text-transform: uppercase; letter-spacing: 0.04em; }
+.sd-failures ul { margin: 0.25rem 0 0; padding-left: 1.25rem; }
+.sd-failures li { font-size: 0.825rem; color: var(--vp-c-text-1); margin: 0.15rem 0; }
+
+/* Disclosures */
+.disclosures { display: flex; flex-direction: column; gap: 0.5rem; }
+
+.disclosure {
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
+  overflow: hidden;
 }
 
-.source-detail-item .value {
-  color: var(--vp-c-text-1, #374151);
-  font-weight: 600;
-  word-break: break-all;
-}
-
-.source-detail-item .value.monospace,
-.record-card .monospace {
-  font-family: var(--vp-font-family-mono, monospace);
-  font-size: 0.85em;
-}
-
-.source-failure-reasons .label {
-  color: #b91c1c;
-  font-weight: 600;
-  font-size: 0.85rem;
-}
-
-.source-failure-reasons ul {
-  margin: 0.25rem 0 0;
-  padding-left: 1.25rem;
-}
-
-.source-failure-reasons li {
-  margin: 0.2rem 0;
-  color: var(--vp-c-text-1, #374151);
-}
-
-/* ---- Detailed Records ---- */
-.records-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.collapse-toggle {
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--vp-c-text-1, #374151);
-  padding: 0;
-}
-
-.collapse-toggle:hover {
-  color: var(--vp-c-brand);
-}
-
-.records-list {
-  margin-top: 1rem;
+.disclosure-trigger {
   display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1.25rem;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
 }
+
+.disclosure-trigger::-webkit-details-marker { display: none; }
+.disclosure-trigger:hover { background: var(--vp-c-bg-soft, #f8f9fa); }
+
+.disclosure-label { font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-1, #374151); }
+
+.disclosure-chevron { color: var(--vp-c-text-3, #9ca3af); transition: transform 0.2s; }
+details[open] .disclosure-chevron { transform: rotate(180deg); }
+
+.disclosure-body {
+  padding: 0 1.25rem 1.25rem;
+  border-top: 1px solid var(--vp-c-border-soft, #f1f5f9);
+}
+
+/* Meta list inside disclosures */
+.meta-list { margin: 0.875rem 0 0; display: flex; flex-direction: column; gap: 0.5rem; }
+
+.meta-row {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.875rem;
+}
+
+.meta-row dt { font-weight: 600; color: var(--vp-c-text-2, #6b7280); }
+.meta-row dd { margin: 0; color: var(--vp-c-text-1); word-break: break-all; }
+.meta-row dd.mono { font-family: monospace; font-size: 0.8rem; }
+
+/* Proto badges */
+.proto-badge {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.proto-badge.pass  { background: rgba(22,163,74,0.1);  color: #15803d; }
+.proto-badge.warn  { background: rgba(217,119,6,0.1);  color: #b45309; }
+.proto-badge.muted { background: var(--vp-c-bg-mute, #f1f5f9); color: var(--vp-c-text-2, #6b7280); }
+
+/* Detailed records */
+.records-list { display: flex; flex-direction: column; gap: 0.625rem; margin-top: 1rem; }
 
 .record-card {
-  padding: 0.875rem 1.125rem;
+  padding: 0.875rem 1rem;
   border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  border-radius: 10px;
-  background: var(--vp-c-bg, #ffffff);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-}
-
-.record-card:hover {
-  border-color: var(--vp-c-border, #d1d5db);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+  border-radius: 9px;
+  background: var(--vp-c-bg, #fff);
 }
 
 .record-head {
@@ -1777,319 +1170,173 @@ onMounted(async () => {
   margin-bottom: 0.625rem;
 }
 
-.record-id {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  min-width: 0;
-}
+.record-id { display: flex; align-items: center; gap: 0.5rem; min-width: 0; }
+.record-ip { font-weight: 600; font-size: 0.875rem; }
+.record-count { font-size: 0.75rem; color: var(--vp-c-text-3, #9ca3af); }
+.record-badges { display: flex; align-items: center; gap: 0.375rem; }
 
-.record-id .ip {
-  font-weight: 600;
-  font-size: 0.9rem;
-  color: var(--vp-c-text-1, #1f2937);
-}
-
-.record-count {
-  color: var(--vp-c-text-3, #9ca3af);
-  font-size: 0.8rem;
-  font-weight: 500;
-}
-
-.record-badges {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  flex-shrink: 0;
-}
-
-/* Status dot, the single source of color */
 .status-dot {
-  width: 8px;
-  height: 8px;
+  width: 8px; height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
   background: var(--vp-c-text-3, #9ca3af);
 }
-
 .status-dot.pass { background: #16a34a; }
 .status-dot.warn { background: #d97706; }
 .status-dot.fail { background: #dc2626; }
 .status-dot.muted { background: var(--vp-c-text-3, #c3c8cf); }
 
-/* Soft pill for the headline verdict */
 .status-pill {
-  padding: 0.125rem 0.625rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
-.status-pill.pass {
-  background: rgba(22, 163, 74, 0.1);
-  color: #15803d;
-}
-
-.status-pill.fail {
-  background: rgba(220, 38, 38, 0.08);
-  color: #b91c1c;
-}
-
-/* Neutral chips for secondary facts (disposition, forwarded) */
-.chip {
-  padding: 0.125rem 0.5rem;
+  padding: 0.1rem 0.55rem;
   border-radius: 999px;
   font-size: 0.72rem;
+  font-weight: 600;
+}
+.status-pill.pass { background: rgba(22,163,74,0.1); color: #15803d; }
+.status-pill.fail { background: rgba(220,38,38,0.08); color: #b91c1c; }
+
+.chip {
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
   font-weight: 500;
   color: var(--vp-c-text-2, #6b7280);
   background: var(--vp-c-bg-soft, #f3f4f6);
   border: 1px solid var(--vp-c-border-soft, #e5e7eb);
 }
 
-/* SPF / DKIM rows */
-.record-auth {
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-}
+.record-auth { display: flex; flex-direction: column; gap: 0.3rem; }
 
 .record-auth-row {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.5rem;
-  font-size: 0.85rem;
-  line-height: 1.5;
-}
-
-.record-auth-row .status-dot {
-  align-self: center;
+  font-size: 0.825rem;
 }
 
 .auth-label {
-  width: 2.75rem;
-  flex-shrink: 0;
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
+  width: 2.5rem;
+  font-size: 0.68rem;
+  font-weight: 700;
   text-transform: uppercase;
+  letter-spacing: 0.05em;
   color: var(--vp-c-text-3, #9ca3af);
+  flex-shrink: 0;
 }
 
-.auth-text {
-  color: var(--vp-c-text-1, #374151);
-  min-width: 0;
-}
+.auth-text { color: var(--vp-c-text-1); }
+.mono { font-family: monospace; font-size: 0.85em; }
 
-/* Muted meta footer */
 .record-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem 1rem;
-  margin-top: 0.625rem;
-  padding-top: 0.625rem;
-  border-top: 1px solid var(--vp-c-divider-light, #f3f4f6);
-  font-size: 0.78rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--vp-c-border-soft, #f1f5f9);
+  font-size: 0.75rem;
   color: var(--vp-c-text-3, #9ca3af);
 }
 
-.record-meta-item .monospace {
-  color: var(--vp-c-text-2, #6b7280);
+/* Tooltip */
+.tip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem; height: 1rem;
+  border-radius: 50%;
+  background: var(--vp-c-brand);
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  cursor: help;
+  position: relative;
+  vertical-align: middle;
 }
 
-/* Dark Mode */
-@media (prefers-color-scheme: dark) {
-  .form-fields-container.drag-hover {
-    background: rgba(19, 176, 238, 0.03);
-  }
-  
-  .drag-overlay-fields {
-    background: rgba(19, 176, 238, 0.12);
-    border-color: rgba(19, 176, 238, 0.4);
-  }
-  
-  .drag-content {
-    background: rgba(30, 30, 30, 0.95);
-    border-color: rgba(19, 176, 238, 0.3);
-  }
-  
-  .recommendations-section,
-  .recommendations-section ul,
-  .recommendations-section li {
-    color: #2d3748 !important;
-  }
+.tip-pop {
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 8px);
+  transform: translateX(-50%) translateY(-4px);
+  width: max-content;
+  max-width: min(280px, 90vw);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+  box-shadow: 0 8px 24px rgba(0,0,0,.12);
+  color: var(--vp-c-text-1, #374151);
+  font-size: 0.8rem;
+  font-weight: 400;
+  line-height: 1.5;
+  z-index: 1000;
+  transition: opacity 0.15s, transform 0.15s;
+  word-wrap: break-word;
+}
 
-  .warnings-section,
-  .warnings-section ul,
-  .warnings-section li {
-    color: #2d3748 !important;
-  }
+.tip:hover .tip-pop,
+.tip:focus .tip-pop {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
 
-  .dkim-notice-section {
-    background: rgba(59, 130, 246, 0.1);
-  }
+/* ── Dark mode ── */
+.dark .hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.09) 0%, hsla(197,87%,50%,0.06) 100%); border-color: rgba(22,163,74,0.25); }
+.dark .hero-warn { background: rgba(217,119,6,0.09); border-color: rgba(217,119,6,0.25); }
+.dark .hero-fail { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.22); }
 
-  .dkim-notice-section h4,
-  .dkim-notice-section li {
-    color: #93c5fd;
-  }
+.dark .icon-pass { background: rgba(22,163,74,0.18); color: #4ade80; }
+.dark .icon-warn { background: rgba(217,119,6,0.18);  color: #fbbf24; }
+.dark .icon-fail { background: rgba(220,38,38,0.18);  color: #f87171; }
 
-  .test-mode-rec-section {
-    background: rgba(59, 130, 246, 0.1);
-  }
+.dark .score-strong, .dark .score-excellent { background: rgba(22,163,74,0.2); color: #4ade80; }
+.dark .score-good,   .dark .score-medium   { background: rgba(217,119,6,0.2);  color: #fbbf24; }
+.dark .score-poor,   .dark .score-weak     { background: rgba(220,38,38,0.2);  color: #f87171; }
 
-  .test-mode-rec-section h4,
-  .test-mode-rec-section li {
-    color: #93c5fd;
-  }
-  
-  .info-tip-pop {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-    box-shadow: 0 8px 24px rgba(0,0,0,.3);
-  }
-  
-  .info-tip-pop::before {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-  }
+.dark .alert-warn  { background: rgba(217,119,6,0.1);   border-color: rgba(217,119,6,0.25);  color: var(--vp-c-text-1); }
+.dark .alert-error { background: rgba(220,38,38,0.1);   border-color: rgba(220,38,38,0.25);  color: #fca5a5; }
+.dark .alert-tip   { background: hsla(197,87%,50%,0.08); border-color: hsla(197,87%,50%,0.25); color: var(--vp-c-text-1); }
+.dark .alert-tip > svg { color: var(--vp-c-brand-light); }
 
-  .proto-badge.pass { background: rgba(34, 187, 51, 0.15); color: #6ee787; }
-  .proto-badge.warn { background: rgba(214, 158, 46, 0.15); color: #f0c36b; }
-  .proto-badge.fail { background: rgba(234, 67, 53, 0.15); color: #f1948a; }
+.dark .proto-badge.pass { background: rgba(22,163,74,0.2);  color: #4ade80; }
+.dark .proto-badge.warn { background: rgba(217,119,6,0.2);  color: #fbbf24; }
 
-  .auth-stat {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-  }
+.dark .auth-stat { background: var(--vp-c-bg-soft, #252736); border-color: var(--vp-c-border, #3a3d50); }
+.dark .status-pill.pass { background: rgba(22,163,74,0.18); color: #4ade80; }
+.dark .status-pill.fail { background: rgba(220,38,38,0.18); color: #f87171; }
+.dark .chip { background: var(--vp-c-bg-mute, #2a2d3e); border-color: var(--vp-c-border, #3a3d50); }
 
-  .record-card {
-    background: var(--vp-c-bg-soft, #1e2030);
-    border-color: var(--vp-c-border, #2e3142);
-  }
+.dark .tip-pop {
+  background: var(--vp-c-bg-soft, #252736);
+  border-color: var(--vp-c-border, #404040);
+  box-shadow: 0 8px 24px rgba(0,0,0,.3);
+}
 
-  .record-card:hover {
-    border-color: var(--vp-c-border, #3e4156);
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
-  }
-
-  .status-pill.pass { background: rgba(22, 163, 74, 0.18); color: #6ee787; }
-  .status-pill.fail { background: rgba(220, 38, 38, 0.18); color: #f1948a; }
-
-  .chip {
-    background: var(--vp-c-bg-mute, #2a2d3e);
-    border-color: var(--vp-c-border, #3a3d50);
-  }
-
-  .record-meta {
-    border-top-color: var(--vp-c-border, #2e3142);
-  }
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  .hero { padding: 1.25rem; gap: 1rem; }
+  .hero-stats { gap: 0.75rem; }
+  .stat-num { font-size: 1.3rem; }
+  .hero-stat-divider { height: 1.5rem; }
+  .auth-stats { grid-template-columns: repeat(2, 1fr); }
+  .meta-row { grid-template-columns: 1fr; gap: 0.15rem; }
+  .meta-row dt { color: var(--vp-c-text-2); }
 }
 
 @media (max-width: 480px) {
-  .info-tip-pop {
+  .hero { flex-wrap: wrap; }
+  .hero-stats { width: 100%; justify-content: space-around; }
+  .tip-pop {
     position: fixed;
-    left: 10px !important;
-    right: 10px !important;
-    top: auto !important;
-    bottom: 20px;
+    left: 10px !important; right: 10px !important;
+    top: auto !important; bottom: 20px;
     transform: none !important;
-    width: auto !important;
-    max-width: none !important;
+    width: auto !important; max-width: none !important;
     z-index: 9999;
   }
-  
-  .info-tip-pop::before {
-    display: none;
-  }
-  
-  .info-tip:hover .info-tip-pop,
-  .info-tip:focus .info-tip-pop {
-    transform: none !important;
-  }
-}
-
-/* Responsive */
-@media (max-width: 768px) {
-  .dmarc-analyzer {
-    padding: 0 0.5rem;
-  }
-  
-  .tool-form {
-    padding: 1rem;
-    margin: 1rem 0;
-  }
-  
-  .drag-content {
-    padding: 1rem;
-  }
-  
-  .drag-icon {
-    font-size: 1.75rem;
-  }
-  
-  .drag-text {
-    font-size: 1rem;
-  }
-  
-  .drag-subtext {
-    font-size: 0.8rem;
-  }
-  
-  .summary-grid,
-  .policy-grid {
-    grid-template-columns: 1fr;
-  }
-  
-  .table-header {
-    display: none;
-  }
-  
-  .table-row {
-    display: flex;
-    flex-direction: column;
-    text-align: left;
-    padding: 1rem;
-    border-bottom: 1px solid var(--vp-c-border-soft, #eee);
-    gap: 0.5rem;
-  }
-  
-  .file-name-row {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
-  }
-
-  .auth-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .source-detail-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .expand-arrow {
-    display: none;
-  }
-
-  .table-row .domain {
-    white-space: normal;
-    overflow: visible;
-    text-overflow: clip;
-    word-break: break-all;
-  }
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .info-tip {
-    width: 1.25rem;
-    height: 1.25rem;
-    line-height: 1.25rem;
-  }
-  
-  .info-tip-pop {
-    padding: 1rem 1.25rem;
-    font-size: .875rem;
-  }
+  .tip:hover .tip-pop, .tip:focus .tip-pop { transform: none !important; }
 }
 </style>

--- a/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
+++ b/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
@@ -64,13 +64,24 @@ const regularRecommendations = computed(() =>
 const ALIGNMENT_LABELS  = { aligned: 'Aligned', unaligned: 'Not aligned', mixed: 'Mixed', no_data: 'No data' }
 const ALIGNMENT_CLASSES = { aligned: 'pass', unaligned: 'fail', mixed: 'warn', no_data: 'muted' }
 
-function alignmentLabel(v) { return ALIGNMENT_LABELS[v] || v || '-' }
-function alignmentClass(v) { return ALIGNMENT_CLASSES[v] || 'muted' }
+function alignmentLabel(v) {
+  return ALIGNMENT_LABELS[v] || v || '-'
+}
+
+function alignmentClass(v) {
+  return ALIGNMENT_CLASSES[v] || 'muted'
+}
 
 function authDotClass(status) {
-  if (status === 'aligned_pass')   return 'pass'
-  if (status === 'unaligned_pass') return 'warn'
-  if (status === 'auth_fail')      return 'fail'
+  if (status === 'aligned_pass') {
+    return 'pass'
+  }
+  if (status === 'unaligned_pass') {
+    return 'warn'
+  }
+  if (status === 'auth_fail') {
+    return 'fail'
+  }
   return 'muted'
 }
 
@@ -80,10 +91,17 @@ function toggleSource(ip) {
   expandedSources.value = next
 }
 
-function isSourceExpanded(ip) { return expandedSources.value.has(ip) }
+function isSourceExpanded(ip) {
+  return expandedSources.value.has(ip)
+}
 
-function onTurnstileVerified(token) { turnstileToken.value = token }
-function onTurnstileInvalid()       { turnstileToken.value = '' }
+function onTurnstileVerified(token) {
+  turnstileToken.value = token
+}
+
+function onTurnstileInvalid() {
+  turnstileToken.value = ''
+}
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -125,7 +143,10 @@ function handleDrop(e) {
 
 function handleFileChange(e) {
   const selected = e.target.files[0]
-  if (!selected) { clearFile(); return }
+  if (!selected) {
+    clearFile()
+    return
+  }
   if (!selected.name.endsWith('.xml')) {
     errorMessage.value = 'Only XML files are supported.'
     clearFile()
@@ -163,7 +184,10 @@ async function analyzeReport() {
   errorMessage.value   = ''
 
   try {
-    if (!validateInputs()) { loading.value = false; return }
+    if (!validateInputs()) {
+      loading.value = false
+      return
+    }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()

--- a/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
+++ b/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
@@ -6,22 +6,22 @@ import Turnstile from './Turnstile.vue'
 
 const MAX_FILENAME_LEN = 30
 
-const xmlPaste  = ref('')
-const file      = ref(null)
-const fileName  = ref('')
-const loading   = ref(false)
-const result    = ref(null)
+const xmlPaste = ref('')
+const file = ref(null)
+const fileName = ref('')
+const loading = ref(false)
+const result = ref(null)
 const errorMessage = ref('')
 
 const isDragging = ref(false)
 let dragLeaveTimeout = null
 
-const fileInputRef   = ref(null)
-const turnstileRef   = ref(null)
+const fileInputRef = ref(null)
+const turnstileRef = ref(null)
 const turnstileToken = ref('')
 
 const expandedSources = ref(new Set())
-const showRecords     = ref(false)
+const showRecords = ref(false)
 
 const isFormDisabled = computed(() =>
   loading.value || (!xmlPaste.value.trim() && !file.value)
@@ -37,8 +37,8 @@ const truncatedFileName = computed(() => {
   return `${fileName.value.slice(0, 15)}...${fileName.value.slice(-10)}`
 })
 
-const hasEnvelopeFrom  = computed(() => result.value?.sources?.some(s => s.envelopeFrom != null) ?? false)
-const hasSpfScope      = computed(() => result.value?.sources?.some(s => s.spfScope != null) ?? false)
+const hasEnvelopeFrom = computed(() => result.value?.sources?.some(s => s.envelopeFrom != null) ?? false)
+const hasSpfScope = computed(() => result.value?.sources?.some(s => s.spfScope != null) ?? false)
 const hasAlignmentData = computed(() => result.value?.sources?.some(s => s.spfAlignment !== undefined) ?? false)
 
 const sourcesGridColumns = computed(() => {
@@ -56,10 +56,10 @@ const sourcesGridColumns = computed(() => {
   return cols.join(' ')
 })
 
-const dkimWarnings    = computed(() => result.value?.warnings?.filter(w => /dkim.*selector|selector.*dkim/i.test(w)) ?? [])
+const dkimWarnings = computed(() => result.value?.warnings?.filter(w => /dkim.*selector|selector.*dkim/i.test(w)) ?? [])
 const regularWarnings = computed(() => result.value?.warnings?.filter(w => !/dkim.*selector|selector.*dkim/i.test(w)) ?? [])
 
-const testModeRecommendations  = computed(() => result.value?.recommendations?.filter(r => /policy[_\s]?test[_\s]?mode|test\s?mode/i.test(r)) ?? [])
+const testModeRecommendations = computed(() => result.value?.recommendations?.filter(r => /policy[_\s]?test[_\s]?mode|test\s?mode/i.test(r)) ?? [])
 const forwardingRecommendations = computed(() =>
   result.value?.recommendations?.filter(r => /forwarded mail|forwarding/i.test(r) && !/policy[_\s]?test[_\s]?mode/i.test(r)) ?? []
 )
@@ -69,7 +69,7 @@ const regularRecommendations = computed(() =>
   ) ?? []
 )
 
-const ALIGNMENT_LABELS  = { aligned: 'Aligned', unaligned: 'Not aligned', mixed: 'Mixed', no_data: 'No data' }
+const ALIGNMENT_LABELS = { aligned: 'Aligned', unaligned: 'Not aligned', mixed: 'Mixed', no_data: 'No data' }
 const ALIGNMENT_CLASSES = { aligned: 'pass', unaligned: 'fail', mixed: 'warn', no_data: 'muted' }
 
 function alignmentLabel(v) {

--- a/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
+++ b/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
@@ -189,11 +189,11 @@ function formatOverride(reason) {
 }
 
 async function analyzeReport() {
-  result.value         = null
+  result.value = null
   expandedSources.value = new Set()
-  showRecords.value    = false
-  loading.value        = true
-  errorMessage.value   = ''
+  showRecords.value = false
+  loading.value = true
+  errorMessage.value = ''
 
   try {
     if (!validateInputs()) {

--- a/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
+++ b/.vitepress/theme/free-tools/DmarcReportAnalyzer.vue
@@ -28,8 +28,12 @@ const isFormDisabled = computed(() =>
 )
 
 const truncatedFileName = computed(() => {
-  if (!fileName.value) return ''
-  if (fileName.value.length <= MAX_FILENAME_LEN) return fileName.value
+  if (!fileName.value) {
+    return ''
+  }
+  if (fileName.value.length <= MAX_FILENAME_LEN) {
+    return fileName.value
+  }
   return `${fileName.value.slice(0, 15)}...${fileName.value.slice(-10)}`
 })
 
@@ -42,8 +46,12 @@ const sourcesGridColumns = computed(() => {
   if (hasAlignmentData.value) {
     cols.push('1.2fr', '1.2fr', '0.5fr')
   } else {
-    if (hasEnvelopeFrom.value) cols.push('2fr')
-    if (hasSpfScope.value)     cols.push('1fr')
+    if (hasEnvelopeFrom.value) {
+      cols.push('2fr')
+    }
+    if (hasSpfScope.value) {
+      cols.push('1fr')
+    }
   }
   return cols.join(' ')
 })
@@ -118,7 +126,9 @@ function validateInputs() {
 
 function handleDragOver(e) {
   e.preventDefault()
-  if (dragLeaveTimeout) clearTimeout(dragLeaveTimeout)
+  if (dragLeaveTimeout) {
+    clearTimeout(dragLeaveTimeout)
+  }
   isDragging.value = true
 }
 
@@ -165,7 +175,9 @@ function clearFile() {
 }
 
 function formatDateRange(dateRange) {
-  if (!dateRange) return 'Unknown'
+  if (!dateRange) {
+    return 'Unknown'
+  }
   if (dateRange.start && dateRange.end) {
     return `${new Date(dateRange.start * 1000).toLocaleString()} – ${new Date(dateRange.end * 1000).toLocaleString()}`
   }
@@ -206,7 +218,9 @@ async function analyzeReport() {
     clearFile()
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) resetTurnstile()
+    if (err.status === 401) {
+      resetTurnstile()
+    }
   } finally {
     loading.value = false
   }
@@ -218,7 +232,7 @@ onMounted(async () => { await nextTick() })
 <template>
   <div class="dmarc-analyzer">
 
-    <!-- ── Upload form ── -->
+    <!-- Upload form -->
     <div class="upload-card"
       :class="{ 'drag-active': isDragging }"
       @dragover="handleDragOver"
@@ -287,13 +301,13 @@ onMounted(async () => { await nextTick() })
       </form>
     </div>
 
-    <!-- ── Error ── -->
+    <!-- Error -->
     <div v-if="errorMessage" class="error-pill">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
       {{ errorMessage }}
     </div>
 
-    <!-- ── Results ── -->
+    <!-- Results -->
     <div v-if="result" class="results">
 
       <!-- Hero -->
@@ -639,7 +653,7 @@ onMounted(async () => { await nextTick() })
   padding: 0 1rem 3rem;
 }
 
-/* ── Upload card ── */
+/* Upload card */
 .upload-card {
   position: relative;
   margin: 2rem 0 1.5rem;
@@ -1307,7 +1321,7 @@ details[open] .disclosure-chevron { transform: rotate(180deg); }
   transform: translateX(-50%) translateY(0);
 }
 
-/* ── Dark mode ── */
+/* Dark mode */
 .dark .hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.09) 0%, hsla(197,87%,50%,0.06) 100%); border-color: rgba(22,163,74,0.25); }
 .dark .hero-warn { background: rgba(217,119,6,0.09); border-color: rgba(217,119,6,0.25); }
 .dark .hero-fail { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.22); }
@@ -1339,7 +1353,7 @@ details[open] .disclosure-chevron { transform: rotate(180deg); }
   box-shadow: 0 8px 24px rgba(0,0,0,.3);
 }
 
-/* ── Responsive ── */
+/* Responsive */
 @media (max-width: 640px) {
   .hero { padding: 1.25rem; gap: 1rem; }
   .hero-stats { gap: 0.75rem; }

--- a/.vitepress/theme/free-tools/LinkChecker.vue
+++ b/.vitepress/theme/free-tools/LinkChecker.vue
@@ -474,11 +474,19 @@ onUnmounted(() => {
     <div class="link-checker">
       <div v-if="!result" class="form-stage">
         <div class="form-container">
-          <h2 class="form-title">HTML Email Link Checker</h2>          
+          <div class="form-header">
+            <div class="form-icon">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            </div>
+            <div>
+              <h2 class="form-title">HTML Email Link Checker</h2>
+              <p class="form-subtitle">Paste your template to extract and test every link before you send.</p>
+            </div>
+          </div>
           <div class="tool-form">
             <form @submit.prevent="checkLinksHandler">
               <div class="form-group">
-                <label for="htmlTemplate">HTML Email Template:</label>
+                <label for="htmlTemplate">HTML Email Template</label>
                 <textarea
                   id="htmlTemplate"
                   v-model="htmlTemplate"
@@ -496,7 +504,7 @@ Example:
                   required
                 ></textarea>
                 <small class="form-help">
-                  Paste your HTML email template here. All hyperlinks will be automatically extracted and checked.
+                  All hyperlinks will be automatically extracted and checked.
                 </small>
               </div>
 
@@ -571,8 +579,11 @@ Example:
 
               <div v-else-if="htmlTemplate.trim()" class="form-group">
                 <div class="no-links-warning">
-                  <p>Warning: No valid links found in your HTML template.</p>
-                  <small>Make sure your HTML contains &lt;a href="..."&gt; tags with valid URLs.</small>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                  <div>
+                    <p>No valid links found in your HTML template.</p>
+                    <small>Make sure your HTML contains &lt;a href="..."&gt; tags with valid URLs.</small>
+                  </div>
                 </div>
               </div>
 
@@ -598,8 +609,9 @@ Example:
             </form>
           </div>
 
-          <div v-if="errorMessage" class="error-section">
-            <p class="error-message">{{ errorMessage }}</p>
+          <div v-if="errorMessage" class="error-pill">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+            {{ errorMessage }}
           </div>
         </div>
       </div>
@@ -608,7 +620,8 @@ Example:
         <div class="results-header">
           <h2>Link Check Results</h2>
           <button @click="resetToForm" class="back-btn">
-            ← Back to Form
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+            Back to Form
           </button>
         </div>
 
@@ -1140,12 +1153,36 @@ Example:
   max-width: 1200px;
 }
 
+.form-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.875rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: hsla(197, 87%, 50%, 0.12);
+  color: var(--vp-c-brand-dark, #0891b2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
 .form-title {
-  text-align: center;
-  margin-bottom: 2rem;
-  font-size: 1.75rem;
+  margin: 0 0 0.25rem;
+  font-size: 1.4rem;
   font-weight: 700;
   color: var(--vp-c-text-1, #1e293b);
+}
+
+.form-subtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--vp-c-text-2, #6b7280);
 }
 
 .results-stage {
@@ -1177,14 +1214,18 @@ Example:
 }
 
 .back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   background: var(--vp-c-bg-soft, #f8f9fa);
   border: 1px solid var(--vp-c-border, #ddd);
   margin-top: 1rem;
   padding: 0.5rem 1rem;
-  border-radius: 6px;
+  border-radius: 999px;
   cursor: pointer;
   color: var(--vp-c-text-1, #333);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
   transition: all 0.2s ease;
   flex-shrink: 0;
 }
@@ -1226,11 +1267,11 @@ Example:
 }
 
 .tool-form {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 12px;
+  background: var(--vp-c-bg, #fff);
+  border-radius: 14px;
   border: 1px solid var(--vp-c-border, #e5e7eb);
-  padding: 2rem;
-  margin-bottom: 2rem;
+  padding: 1.75rem;
+  margin-bottom: 1.5rem;
 }
 
 .form-group {
@@ -1249,10 +1290,10 @@ Example:
 .form-group textarea {
   width: 100%;
   padding: 0.875rem 1rem;
-  border: 2px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 8px;
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
   font-size: 1rem;
-  transition: border-color 0.2s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
   box-sizing: border-box;
   background: var(--vp-c-bg, #ffffff);
   color: var(--vp-c-text-1, #374151);
@@ -1268,7 +1309,7 @@ Example:
 .form-group textarea:focus {
   outline: none;
   border-color: var(--vp-c-brand);
-  box-shadow: 0 0 0 3px rgba(19, 176, 238, 0.1);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
 }
 
 .form-group input:disabled,
@@ -1526,112 +1567,24 @@ Example:
   box-sizing: border-box;
 }
 
-.captcha-expired-message {
-  background: #fff3cd;
-  border: 1px solid #ffc107;
-  color: #856404;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1rem;
-  font-size: 0.875rem;
-}
-
-.captcha-container {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.captcha-image-container {
-  flex: 1;
-  min-height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #ffffff;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 6px;
-  padding: 0.5rem;
-}
-
-.captcha-loading,
-.captcha-placeholder {
-  color: #6b7280;
-  font-style: italic;
-  text-align: center;
-}
-
-.load-captcha-btn {
-  background: var(--vp-c-brand);
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.875rem;
-  transition: all 0.2s ease;
-}
-
-.load-captcha-btn:hover {
-  background: var(--vp-c-brand-light);
-}
-
-.refresh-captcha-btn {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  padding: 0.5rem;
-  border-radius: 6px;
-  cursor: pointer;
-  width: 2.5rem;
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
-}
-
-.refresh-captcha-btn:hover:not(:disabled) {
-  background: var(--vp-c-bg, #ffffff);
-  border-color: var(--vp-c-brand);
-}
-
-.refresh-captcha-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.refresh-captcha-btn img {
-  width: 16px;
-  height: 16px;
-}
-
-.captcha-help {
-  display: block;
-  margin-top: 0.5rem;
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-style: italic;
-}
-
 .check-btn {
   background: var(--vp-c-brand);
   color: #ffffff;
   padding: 0.875rem 2rem;
   border: none;
-  border-radius: 8px;
+  border-radius: 10px;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 600;
   transition: all 0.2s ease;
   width: 100%;
-  box-shadow: 0 2px 4px rgba(19, 176, 238, 0.2);
+  box-shadow: 0 1px 4px hsla(197, 87%, 50%, 0.3);
 }
 
 .check-btn:hover:not(:disabled) {
-  background: var(--vp-c-brand-light);
+  background: var(--vp-c-brand-dark);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(19, 176, 238, 0.25);
+  box-shadow: 0 4px 12px hsla(197, 87%, 50%, 0.35);
 }
 
 .check-btn:disabled {
@@ -1661,35 +1614,45 @@ Example:
   to { transform: rotate(360deg); }
 }
 
-.error-section {
-  background: var(--vp-danger-soft, #f8d7da);
-  color: var(--vp-c-danger-1, #721c24);
-  padding: 1rem;
+.error-pill {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid rgba(220,38,38,0.2);
   border-radius: 8px;
-  margin-bottom: 1rem;
-  border: 1px solid var(--vp-c-danger-2, #f5c6cb);
-}
-
-.error-message {
-  margin: 0;
+  font-size: 0.875rem;
   font-weight: 500;
+  margin-top: 1rem;
 }
 
 .no-links-warning {
-  background: #fff3cd;
-  border: 1px solid #ffc107;
-  color: #856404;
-  padding: 1rem;
-  border-radius: 6px;
+  display: flex;
+  gap: 0.625rem;
+  background: rgba(217,119,6,0.06);
+  border: 1px solid rgba(217,119,6,0.2);
+  color: var(--vp-c-text-1);
+  padding: 0.875rem 1.125rem;
+  border-radius: 10px;
+}
+
+.no-links-warning svg {
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  color: #d97706;
 }
 
 .no-links-warning p {
-  margin: 0 0 0.5rem 0;
-  font-weight: 500;
+  margin: 0 0 0.25rem 0;
+  font-weight: 600;
+  font-size: 0.875rem;
 }
 
 .no-links-warning small {
-  font-size: 0.875rem;
+  font-size: 0.8rem;
+  color: var(--vp-c-text-2, #6b7280);
 }
 
 .results-summary {
@@ -1749,8 +1712,8 @@ Example:
 
 .result-item.selected {
   background: var(--vp-c-bg, #fff);
-  border-color: var(--vp-c-brand, #3b82f6);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: var(--vp-c-brand);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
 }
 
 .result-status {
@@ -2947,24 +2910,6 @@ Example:
     gap: 0.5rem;
   }
 
-  .captcha-container {
-    flex-direction: column;
-    gap: 0.75rem;
-    align-items: stretch;
-  }
-
-  .captcha-image-container {
-    min-height: 60px;
-    padding: 0.75rem;
-  }
-
-  .refresh-captcha-btn {
-    width: 100%;
-    height: 3rem;
-    align-self: center;
-    max-width: 120px;
-  }
-
   .check-btn {
     padding: 1rem 1.5rem;
     font-size: 1rem;
@@ -3152,23 +3097,29 @@ Example:
 }
 
 /* Dark Mode */
-@media (prefers-color-scheme: dark) {
-  .result-item {
-    background: var(--vp-c-bg-soft, #1e2030);
-    border-color: var(--vp-c-border, #2e3142);
-  }
-
-  .result-item:hover {
-    border-color: var(--vp-c-border, #3a3d50);
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
-  }
-
-  .summary-item.working { border-color: rgba(34, 187, 51, 0.3); }
-  .summary-item.broken,
-  .summary-item.error { border-color: rgba(220, 53, 69, 0.3); }
-
-  .detail-error {
-    border-color: rgba(220, 53, 69, 0.3);
-  }
+.dark .result-item {
+  background: var(--vp-c-bg-soft, #1e2030);
+  border-color: var(--vp-c-border, #2e3142);
 }
+
+.dark .result-item:hover {
+  border-color: var(--vp-c-border, #3a3d50);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.dark .summary-item.working { border-color: rgba(34, 187, 51, 0.3); }
+.dark .summary-item.broken,
+.dark .summary-item.error { border-color: rgba(220, 53, 69, 0.3); }
+
+.dark .detail-error {
+  border-color: rgba(220, 53, 69, 0.3);
+}
+
+.dark .form-icon {
+  background: hsla(197, 87%, 50%, 0.18);
+  color: var(--vp-c-brand-light);
+}
+
+.dark .no-links-warning { background: rgba(217,119,6,0.1); border-color: rgba(217,119,6,0.25); }
+.dark .error-pill { background: rgba(220,38,38,0.12); border-color: rgba(220,38,38,0.3); color: #f87171; }
 </style>

--- a/.vitepress/theme/free-tools/MxChecker.vue
+++ b/.vitepress/theme/free-tools/MxChecker.vue
@@ -139,19 +139,20 @@ onMounted(async () => {
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
-        <Turnstile
-          ref="turnstileRef"
-          class="turnstile-inline"
-          :class="{ 'turnstile-collapsed': result }"
-          @verified="onTurnstileVerified"
-          @expired="onTurnstileInvalid"
-          @error="onTurnstileInvalid"
-        />
         <button type="submit" class="search-btn" :disabled="isFormDisabled">
           <span v-if="loading" class="btn-loading"><span class="spinner"></span></span>
           <span v-else>Check MX</span>
         </button>
       </form>
+
+      <Turnstile
+        ref="turnstileRef"
+        class="turnstile-row"
+        :class="{ 'turnstile-collapsed': result }"
+        @verified="onTurnstileVerified"
+        @expired="onTurnstileInvalid"
+        @error="onTurnstileInvalid"
+      />
     </div>
 
     <!-- ── Error ── -->
@@ -199,7 +200,7 @@ onMounted(async () => {
       </div>
 
       <!-- MX records list -->
-      <div v-if="result.records.length" class="card">
+      <div v-if="result.records.length" class="tool-card">
         <h3 class="card-title">Mail Servers</h3>
         <div class="mx-list">
           <div v-for="record in result.records" :key="record.exchange" class="mx-item">
@@ -319,16 +320,18 @@ onMounted(async () => {
   color: var(--vp-c-text-1, #111827);
 }
 
-.turnstile-inline {
-  flex-shrink: 0;
-  transition: opacity 0.2s, max-width 0.2s, max-height 0.2s, margin 0.2s;
+.turnstile-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.75rem;
+  transition: opacity 0.2s, max-height 0.2s, margin 0.2s;
   overflow: hidden;
 }
 
-.turnstile-inline.turnstile-collapsed {
+.turnstile-row.turnstile-collapsed {
   opacity: 0;
-  max-width: 0;
   max-height: 0;
+  margin-top: 0;
   pointer-events: none;
   position: absolute;
 }
@@ -494,7 +497,7 @@ onMounted(async () => {
 .signal-weak   { border-color: rgba(220,38,38,0.2); }
 
 /* Card */
-.card {
+.tool-card {
   background: var(--vp-c-bg, #fff);
   border: 1px solid var(--vp-c-border, #e5e7eb);
   border-radius: 12px;

--- a/.vitepress/theme/free-tools/MxChecker.vue
+++ b/.vitepress/theme/free-tools/MxChecker.vue
@@ -4,29 +4,41 @@ import { checkMx } from '../../../connectors/bluefoxEmailToolsApi.js'
 import { isSessionValid } from '../../../connectors/turnstileSession.js'
 import { syncWithUrl, loadFromUrl } from './helpers/urlSync.js'
 import Turnstile from './Turnstile.vue'
+import SignalIcon from './SignalIcon.vue'
+import ToolSwitcher from './ToolSwitcher.vue'
 
-// ---- VARIABLES ----
-const domain = ref('')
-const loading = ref(false)
-const result = ref(null)
+const domain       = ref('')
+const loading      = ref(false)
+const result       = ref(null)
 const errorMessage = ref('')
 
-// Turnstile state
-const turnstileRef = ref(null)
+const turnstileRef   = ref(null)
 const turnstileToken = ref('')
+const resultsRef = ref(null)
 
-const isFormDisabled = computed(() =>
-  loading.value
-)
+const isFormDisabled = computed(() => loading.value)
 
-// ---- FUNCTIONS ----
-function onTurnstileVerified(token) {
-  turnstileToken.value = token
+function hasUniquePriorities(records) {
+  if (!records?.length) return true
+  return new Set(records.map(r => r.priority)).size === records.length
 }
 
-function onTurnstileInvalid() {
-  turnstileToken.value = ''
-}
+const redundancySignal = computed(() => {
+  const n = result.value?.records?.length ?? 0
+  if (n > 1) return { label: 'Multiple servers', level: 'strong', icon: 'check' }
+  if (n === 1) return { label: 'Single server', level: 'weak', icon: 'alert' }
+  return { label: 'None', level: 'weak', icon: 'alert' }
+})
+
+const priorityShape = computed(() => {
+  if (!result.value?.records?.length) return { label: '—', level: 'muted', icon: 'dot' }
+  return hasUniquePriorities(result.value.records)
+    ? { label: 'Unique priorities', level: 'strong', icon: 'check' }
+    : { label: 'Duplicate priorities', level: 'medium', icon: 'minus' }
+})
+
+function onTurnstileVerified(token) { turnstileToken.value = token }
+function onTurnstileInvalid()       { turnstileToken.value = '' }
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -38,20 +50,16 @@ function validateInputs() {
     errorMessage.value = 'Please enter a domain name'
     return false
   }
-
   return true
 }
 
 async function checkMxHandler() {
-  result.value = null
-  loading.value = true
+  result.value       = null
+  loading.value       = true
   errorMessage.value = ''
 
   try {
-    if (!validateInputs()) {
-      loading.value = false
-      return
-    }
+    if (!validateInputs()) { loading.value = false; return }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
@@ -59,970 +67,527 @@ async function checkMxHandler() {
 
     const data = await checkMx({
       domain: domain.value,
-      turnstileToken: turnstileToken.value
+      turnstileToken: turnstileToken.value,
     })
 
     result.value = {
-      valid: true,
-      domain: data.result.domain || domain.value,
+      valid:   true,
+      domain:  data.result.domain || domain.value,
       records: data.result.records || data.result.mxRecords || [],
-      score: data.result.score,
+      score:   data.result.score,
       warnings: data.result.warnings || [],
-      recommendations: data.result.recommendations || []
+      recommendations: data.result.recommendations || [],
     }
 
     resetTurnstile()
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) {
-      resetTurnstile()
-    }
+    if (err.status === 401) resetTurnstile()
   } finally {
     loading.value = false
   }
 }
 
-function hasUniquePriorities(records) {
-  if (!records?.length) return true
-  return new Set(records.map(r => r.priority)).size === records.length
-}
+watch(domain, () => syncWithUrl({ domain: domain.value }))
 
-// ---- WATCHES ----
-watch(domain, () => {
-  syncWithUrl({ domain: domain.value })
-})
-
-// ---- LIFECYCLE ----
 onMounted(async () => {
-  loadFromUrl({ domain })
+  const urlParams = new URLSearchParams(window.location.search)
 
+  loadFromUrl({ domain })
   await nextTick()
+
+  if (urlParams.get('run') === '1' && domain.value) {
+    await turnstileRef.value?.whenReady()
+    await checkMxHandler()
+    await nextTick()
+    resultsRef.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
 })
 </script>
 
 <template>
   <div class="mx-checker">
-    <div class="tool-form">
-      <form @submit.prevent="checkMxHandler">
-        <div class="form-group">
-          <label for="domain">Domain:</label>
+
+    <ToolSwitcher :domain="domain" />
+
+    <!-- ── Inline form ── -->
+    <div class="search-bar" :class="{ 'has-result': result }">
+      <form class="search-form" @submit.prevent="checkMxHandler">
+        <div class="search-input-wrap">
+          <span class="search-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+            </svg>
+          </span>
           <input
             id="domain"
             v-model="domain"
             type="text"
             placeholder="example.com"
             :disabled="loading"
+            autocomplete="off"
+            spellcheck="false"
             required
           />
+          <button
+            v-if="domain && !loading"
+            type="button"
+            class="search-clear"
+            aria-label="Clear domain"
+            @click="domain = ''"
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
         </div>
-
-        <div class="form-group">
-          <Turnstile
-            ref="turnstileRef"
-            @verified="onTurnstileVerified"
-            @expired="onTurnstileInvalid"
-            @error="onTurnstileInvalid"
-          />
-        </div>
-
-        <button type="submit" class="check-btn" :disabled="isFormDisabled">
-          <span v-if="loading" class="btn-loading">
-            <div class="loading-spinner"></div>
-            Checking...
-          </span>
-          <span v-else>Check MX Records</span>
+        <Turnstile
+          ref="turnstileRef"
+          class="turnstile-inline"
+          :class="{ 'turnstile-collapsed': result }"
+          @verified="onTurnstileVerified"
+          @expired="onTurnstileInvalid"
+          @error="onTurnstileInvalid"
+        />
+        <button type="submit" class="search-btn" :disabled="isFormDisabled">
+          <span v-if="loading" class="btn-loading"><span class="spinner"></span></span>
+          <span v-else>Check MX</span>
         </button>
       </form>
     </div>
 
-    <!-- Error Display -->
-    <div v-if="errorMessage" class="error-section">
-      <p class="error-message">{{ errorMessage }}</p>
+    <!-- ── Error ── -->
+    <div v-if="errorMessage" class="error-pill">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      {{ errorMessage }}
     </div>
 
-    <!-- Results -->
-    <div v-if="result" class="result-section">
-      <h3>MX Records Check Results</h3>
-      
-      <div class="status-box">
-        <p><strong>{{ result.valid ? 'MX Records Found' : 'No MX Records Found' }}</strong></p>
-        <p v-if="result.valid"><strong>Total Records:</strong> {{ result.records.length }}</p>
-        <p v-if="result.score">
-          <strong>Security Score:</strong>
-          {{ result.score.value }}/{{ result.score.outOf }} ({{ result.score.level }})
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Assessment based on redundancy, priority configuration, and mail server setup quality.</span>
-          </span>
-        </p>
+    <!-- ── Results ── -->
+    <div v-if="result" class="results" ref="resultsRef">
+
+      <!-- Hero -->
+      <div class="hero" :class="result.valid && result.records.length ? 'hero-pass' : 'hero-fail'">
+        <div class="hero-icon" :class="result.valid && result.records.length ? 'icon-pass' : 'icon-fail'">
+          <svg v-if="result.valid && result.records.length" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          <svg v-else width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </div>
+        <div class="hero-text">
+          <h2 class="hero-title">{{ result.records.length ? 'MX Records Found' : 'No MX Records' }}</h2>
+          <p class="hero-domain">{{ result.domain }}</p>
+        </div>
+        <div v-if="result.score" class="hero-score">
+          <span class="score-num">{{ result.score.value }}<span class="score-denom">/{{ result.score.outOf }}</span></span>
+          <span class="score-label" :class="'score-' + result.score.level?.toLowerCase()">{{ result.score.level }}</span>
+        </div>
       </div>
 
-      <div class="info-section">
-        <h4>
-          Basic Information
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Essential details about the mail exchange configuration for this domain.</span>
-          </span>
-        </h4>
-        <p><strong>Domain:</strong> {{ result.domain }}</p>
-        <p>
-          <strong>Records Found:</strong> {{ result.records.length }}
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">MX records tell email servers where to deliver mail for this domain. Multiple records provide redundancy.</span>
-          </span>
-        </p>
+      <!-- Signals grid -->
+      <div v-if="result.records.length" class="signals-grid">
+        <div class="signal" :class="'signal-' + redundancySignal.level">
+          <span class="signal-icon"><SignalIcon :name="redundancySignal.icon" /></span>
+          <span class="signal-name">Redundancy</span>
+          <span class="signal-value">{{ redundancySignal.label }}</span>
+        </div>
+        <div class="signal" :class="'signal-' + priorityShape.level">
+          <span class="signal-icon"><SignalIcon :name="priorityShape.icon" /></span>
+          <span class="signal-name">Priorities</span>
+          <span class="signal-value">{{ priorityShape.label }}</span>
+        </div>
+        <div class="signal signal-muted">
+          <span class="signal-icon"><SignalIcon name="dot" /></span>
+          <span class="signal-name">Servers</span>
+          <span class="signal-value">{{ result.records.length }}</span>
+        </div>
       </div>
 
-      <div v-if="result.records.length" class="mx-records-section">
-        <h4>
-          MX Records
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Mail exchange servers listed by priority. Lower priority numbers are preferred for mail delivery.</span>
-          </span>
-        </h4>
-        <div class="mx-records-container">
-          <div class="mx-records-list">
-            <div 
-              v-for="(record, index) in result.records" 
-              :key="record.exchange"
-              class="mx-record-item"
-            >
-              <div class="mx-record-content">
-                <div class="priority-section">
-                  <div class="priority-badge">{{ record.priority }}</div>
-                  <span class="priority-label">Priority</span>
-                </div>
-                <div class="server-section">
-                  <div class="server-name">{{ record.exchange }}</div>
-                  <div class="server-meta">
-                    <span class="server-type">Mail Exchange Server</span>
-                    <span class="server-status">• Active</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          
-          <div class="mx-summary-stats">
-            <div class="stat-card">
-              <div class="stat-number">{{ result.records.length }}</div>
-              <div class="stat-label">Mail Servers</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-number">{{ Math.min(...result.records.map(r => r.priority)) }}</div>
-              <div class="stat-label">Highest Priority</div>
-            </div>
-            <div class="stat-card">
-              <div class="stat-number">{{ hasUniquePriorities(result.records) ? 'Yes' : 'No' }}</div>
-              <div class="stat-label">Unique Priorities</div>
+      <!-- MX records list -->
+      <div v-if="result.records.length" class="card">
+        <h3 class="card-title">Mail Servers</h3>
+        <div class="mx-list">
+          <div v-for="record in result.records" :key="record.exchange" class="mx-item">
+            <div class="priority-badge">{{ record.priority }}</div>
+            <div class="mx-item-text">
+              <div class="mx-host">{{ record.exchange }}</div>
+              <div class="mx-meta">Priority {{ record.priority }}</div>
             </div>
           </div>
         </div>
       </div>
 
-      <div v-if="result.valid" class="section analysis-section">
-        <h4>
-          Analysis
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Quick assessment of your MX record configuration for reliability and best practices.</span>
-          </span>
-        </h4>
-        <div class="analysis-grid">
-          <div class="analysis-item">
-            <span class="label">Redundancy:</span>
-            <span :class="result.records.length > 1 ? 'value good' : 'value warning'">
-              <span class="status-dot" :class="result.records.length > 1 ? 'pass' : 'warn'"></span>
-              {{ result.records.length > 1 ? 'Multiple servers' : 'Single server' }}
-            </span>
-          </div>
-          <div class="analysis-item">
-            <span class="label">Priority setup:</span>
-            <span
-              :class="hasUniquePriorities(result.records) ? 'value good' : 'value warning'"
-            >
-              <span class="status-dot" :class="hasUniquePriorities(result.records) ? 'pass' : 'warn'"></span>
-              {{ hasUniquePriorities(result.records) ? 'Unique priorities' : 'Duplicate priorities' }}
-            </span>
-          </div>
-        </div>
+      <!-- Alerts -->
+      <div v-if="result.warnings?.length" class="alert alert-warn">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <ul><li v-for="w in result.warnings" :key="w">{{ w }}</li></ul>
       </div>
 
-      <div v-if="result.warnings?.length" class="section warnings-section">
-        <h4>Warnings</h4>
-        <ul>
-          <li v-for="warning in result.warnings" :key="warning">{{ warning }}</li>
-        </ul>
+      <div v-if="result.recommendations?.length" class="alert alert-tip">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <ul><li v-for="r in result.recommendations" :key="r">{{ r }}</li></ul>
       </div>
 
-      <div v-if="result.recommendations?.length" class="section recommendations-section">
-        <h4>Recommendations</h4>
-        <ul>
-          <li v-for="rec in result.recommendations" :key="rec">{{ rec }}</li>
-        </ul>
-      </div>
     </div>
   </div>
 </template>
 
 <style scoped>
 .mx-checker {
-  max-width: 800px;
+  max-width: 720px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 1rem 3rem;
 }
 
-.tool-form {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 12px;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
+/* Search bar — shared pattern */
+.search-bar {
+  margin: 2rem 0 1.5rem;
+  transition: margin 0.2s;
 }
 
-.form-group {
-  margin-bottom: 1.5rem;
+.search-bar.has-result {
+  margin: 0 0 1rem;
 }
 
-.form-group label {
-  display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--vp-c-text-1, #374151);
-  font-size: 0.9rem;
-}
-
-.form-group input {
-  width: 100%;
-  padding: 0.875rem 1rem;
-  border: 2px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 8px;
-  font-size: 1rem;
-  transition: border-color 0.2s ease;
-  box-sizing: border-box;
-  background: var(--vp-c-bg, #ffffff);
-  color: var(--vp-c-text-1, #374151);
-}
-
-.form-group input:focus {
-  outline: none;
-  border-color: var(--vp-c-brand);
-  box-shadow: 0 0 0 3px rgba(19, 176, 238, 0.1);
-}
-
-.form-group input:disabled {
-  background: var(--vp-c-bg-mute, #f1f5f9);
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-/* CAPTCHA Styles */
-.captcha-expired-message {
-  background: #fff3cd;
-  border: 1px solid #ffc107;
-  color: #856404;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1rem;
-  font-size: 0.875rem;
-}
-
-.captcha-container {
+.search-form {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  transition: transform 0.2s;
 }
 
-.captcha-image-container {
+.search-input-wrap {
   flex: 1;
-  min-height: 50px;
+  min-width: 220px;
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
-  background: #ffffff;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 6px;
-  padding: 0.5rem;
 }
 
-.captcha-loading,
-.captcha-placeholder {
-  color: #6b7280;
-  font-style: italic;
-  text-align: center;
-}
-
-.load-captcha-btn {
-  background: var(--vp-c-brand);
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.875rem;
-  transition: background-color 0.2s ease;
-}
-
-.load-captcha-btn:hover {
-  background: var(--vp-c-brand-light);
-}
-
-.refresh-captcha-btn {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  padding: 0.5rem;
-  border-radius: 6px;
-  cursor: pointer;
-  width: 2.5rem;
-  height: 2.5rem;
+.search-icon {
+  position: absolute;
+  left: 0.875rem;
+  color: var(--vp-c-text-3, #9ca3af);
   display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
+  pointer-events: none;
 }
 
-.refresh-captcha-btn:hover:not(:disabled) {
-  background: var(--vp-c-bg, #ffffff);
+.search-input-wrap input {
+  width: 100%;
+  padding: 0.75rem 2.25rem 0.75rem 2.5rem;
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
+  font-size: 1rem;
+  background: var(--vp-c-bg, #fff);
+  color: var(--vp-c-text-1, #111827);
+  transition: border-color 0.15s, box-shadow 0.15s, padding 0.2s;
+  box-sizing: border-box;
+}
+
+.has-result .search-input-wrap input {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.search-input-wrap input:focus {
+  outline: none;
   border-color: var(--vp-c-brand);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
 }
 
-.refresh-captcha-btn:disabled {
+.search-input-wrap input:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.refresh-captcha-btn img {
-  width: 16px;
-  height: 16px;
-}
-
-.captcha-help {
-  display: block;
-  margin-top: 0.5rem;
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-style: italic;
-}
-
-/* Button */
-.check-btn {
-  background: var(--vp-c-brand);
-  color: #ffffff;
-  padding: 0.875rem 2rem;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 600;
-  transition: all 0.2s ease;
-  width: 100%;
-  box-shadow: 0 2px 4px rgba(19, 176, 238, 0.2);
-}
-
-.check-btn:hover:not(:disabled) {
-  background: var(--vp-c-brand-light);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(19, 176, 238, 0.25);
-}
-
-.check-btn:active:not(:disabled) {
-  background: var(--vp-c-brand-dark);
-  transform: translateY(0);
-}
-
-.check-btn:disabled {
-  background: var(--vp-c-bg-mute, #9ca3af);
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-.btn-loading {
+.search-clear {
+  position: absolute;
+  right: 0.625rem;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
   justify-content: center;
-}
-
-.loading-spinner {
-  width: 12px;
-  height: 12px;
-  border: 1.5px solid rgba(255, 255, 255, 0.3);
-  border-top: 1.5px solid #ffffff;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: var(--vp-c-bg-mute, #f1f5f9);
+  color: var(--vp-c-text-2, #6b7280);
   border-radius: 50%;
-  animation: spin 1s linear infinite;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
 }
 
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+.search-clear:hover {
+  background: var(--vp-c-bg-soft, #e5e7eb);
+  color: var(--vp-c-text-1, #111827);
 }
 
-/* Error Section */
-.error-section {
-  background: var(--vp-danger-soft, #f8d7da);
-  color: var(--vp-c-danger-1, #721c24);
-  padding: 1rem;
-  border-radius: 8px;
-  margin: 1rem 0;
-  border: 1px solid var(--vp-c-danger-2, #f5c6cb);
+.turnstile-inline {
+  flex-shrink: 0;
+  transition: opacity 0.2s, max-width 0.2s, max-height 0.2s, margin 0.2s;
+  overflow: hidden;
 }
 
-.error-message {
-  margin: 0;
-  font-weight: 500;
-}
-
-/* Results Section */
-.result-section {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.result-section h3 {
-  margin: 0 0 1.5rem 0;
-  color: var(--vp-c-text-1, #1a202c);
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.status-box {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  padding: 1.25rem;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 8px;
-  margin-bottom: 1.5rem;
-}
-
-.status-box p {
-  margin: 0.5rem 0;
-  font-size: 1rem;
-}
-
-/* Info Section */
-.info-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.info-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.info-section p {
-  margin: 0.75rem 0;
-  color: var(--vp-c-text-2, #4a5568);
-  line-height: 1.6;
-}
-
-/* Info tip styles */
-.info-tip {
-  display: inline-block;
-  margin-left: .3rem;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1rem;
-  text-align: center;
-  border-radius: 50%;
-  background: var(--vp-c-brand);
-  color: #fff;
-  font-size: .675rem;
-  cursor: help;
-  position: relative;
-  vertical-align: middle;
-}
-
-.info-tip-pop {
+.turnstile-inline.turnstile-collapsed {
   opacity: 0;
+  max-width: 0;
+  max-height: 0;
   pointer-events: none;
   position: absolute;
-  left: 50%;
-  top: calc(100% + 8px);
-  transform: translateX(-50%);
-  width: max-content;
-  max-width: min(300px, 90vw);
-  padding: .8rem 1rem;
-  border-radius: 8px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  box-shadow: 0 8px 24px rgba(0,0,0,.12);
-  color: var(--vp-c-text-1, #374151);
-  font-size: .825rem;
-  line-height: 1.5;
-  z-index: 1000;
-  transition: opacity .2s ease, transform .2s ease;
-  transform: translateX(-50%) translateY(-4px);
-  word-wrap: break-word;
-  hyphens: auto;
 }
 
-.info-tip-pop::before {
-  content: '';
-  position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 12px;
-  height: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  border-bottom: none;
-  border-right: none;
-  transform: translateX(-50%) rotate(45deg);
-}
-
-.info-tip:hover .info-tip-pop,
-.info-tip:focus .info-tip-pop {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
-
-.info-tip:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:last-child .info-tip-pop {
-  left: auto;
-  right: 0;
-  transform: translateX(0);
-}
-
-.info-tip:nth-last-child(-n+2) .info-tip-pop::before,
-.info-tip:last-child .info-tip-pop::before {
-  left: auto;
-  right: 1rem;
-  transform: translateX(0) rotate(45deg);
-}
-
-.info-tip:hover:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:focus:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:hover:last-child .info-tip-pop,
-.info-tip:focus:last-child .info-tip-pop {
-  transform: translateX(0) translateY(0);
-}
-
-/* MX Records Section */
-.mx-records-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.mx-records-section h4 {
-  margin: 0 0 1.5rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
+.search-btn {
+  padding: 0.75rem 1.5rem;
+  background: var(--vp-c-brand);
+  color: #fff;
+  font-size: 0.9rem;
   font-weight: 600;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, transform 0.1s, box-shadow 0.15s, padding 0.2s;
+  box-shadow: 0 1px 4px hsla(197, 87%, 50%, 0.3);
+  min-width: 130px;
 }
 
-.mx-records-container {
-  background: var(--vp-c-bg, #ffffff);
-  border-radius: 12px;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+.has-result .search-btn {
+  padding: 0.5rem 1.25rem;
+  min-width: 100px;
+  font-size: 0.825rem;
 }
 
-.mx-records-list {
-  padding: 0;
+.search-btn:hover:not(:disabled) {
+  background: var(--vp-c-brand-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px hsla(197, 87%, 50%, 0.35);
 }
 
-.mx-record-item {
-  border-bottom: 1px solid var(--vp-c-border-soft, #f1f5f9);
-  transition: background-color 0.2s ease;
+.search-btn:active:not(:disabled) { transform: translateY(0); }
+.search-btn:disabled { opacity: 0.55; cursor: not-allowed; box-shadow: none; }
+
+.btn-loading { display: flex; align-items: center; justify-content: center; }
+
+.spinner {
+  display: inline-block;
+  width: 14px; height: 14px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
 }
 
-.mx-record-item:last-child {
-  border-bottom: none;
-}
+@keyframes spin { to { transform: rotate(360deg); } }
 
-.mx-record-item:hover {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-}
-
-.mx-record-content {
-  display: grid;
-  grid-template-columns: 120px 1fr;
-  gap: 1.5rem;
-  padding: 1.5rem;
-  align-items: center;
-}
-
-/* Priority Section */
-.priority-section {
-  display: flex;
-  flex-direction: column;
+/* Error */
+.error-pill {
+  display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid rgba(220,38,38,0.2);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+}
+
+/* Results */
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+/* Hero */
+.hero {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  flex-wrap: wrap;
+}
+
+.hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.06) 0%, hsla(197,87%,50%,0.04) 100%); border-color: rgba(22,163,74,0.2); }
+.hero-fail { background: rgba(220,38,38,0.04); border-color: rgba(220,38,38,0.18); }
+
+.hero-icon {
+  width: 52px; height: 52px;
+  border-radius: 13px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+
+.icon-pass { background: rgba(22,163,74,0.12); color: #16a34a; border: 1px solid rgba(22,163,74,0.2); }
+.icon-fail { background: rgba(220,38,38,0.1);  color: #dc2626; border: 1px solid rgba(220,38,38,0.15); }
+
+.hero-text { flex: 1; min-width: 0; }
+
+.hero-title {
+  margin: 0 0 0.2rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1, #111827);
+}
+
+.hero-domain {
+  margin: 0;
+  font-size: 0.8rem;
+  font-family: monospace;
+  color: var(--vp-c-text-2, #6b7280);
+}
+
+.hero-score { display: flex; flex-direction: column; align-items: center; flex-shrink: 0; }
+
+.score-num {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: var(--vp-c-text-1, #111827);
+  line-height: 1;
+}
+
+.score-denom { font-size: 0.9rem; font-weight: 500; color: var(--vp-c-text-3, #9ca3af); }
+
+.score-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  margin-top: 0.25rem;
+}
+
+.score-strong, .score-excellent { background: rgba(22,163,74,0.12); color: #15803d; }
+.score-good, .score-medium      { background: rgba(217,119,6,0.12);  color: #b45309; }
+.score-poor, .score-weak        { background: rgba(220,38,38,0.1);   color: #dc2626; }
+
+/* Signals grid */
+.signals-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.625rem;
+}
+
+.signal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.75rem 0.875rem;
+  border-radius: 10px;
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+  background: var(--vp-c-bg, #fff);
+}
+
+.signal-icon { display: inline-flex; align-items: center; }
+.signal-name { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--vp-c-text-2, #6b7280); }
+.signal-value { font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-1, #111827); }
+
+.signal-strong .signal-icon { color: #16a34a; }
+.signal-medium .signal-icon { color: #d97706; }
+.signal-weak   .signal-icon { color: #dc2626; }
+.signal-muted  .signal-icon { color: var(--vp-c-text-3, #9ca3af); }
+
+.signal-strong { border-color: rgba(22,163,74,0.25); }
+.signal-medium { border-color: rgba(217,119,6,0.25); }
+.signal-weak   { border-color: rgba(220,38,38,0.2); }
+
+/* Card */
+.card {
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+}
+
+.card-title {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-text-1, #374151);
+}
+
+/* MX list */
+.mx-list { display: flex; flex-direction: column; gap: 0.5rem; }
+
+.mx-item {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 0.75rem 0.875rem;
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+  border-radius: 9px;
+  background: var(--vp-c-bg-soft, #f8f9fa);
 }
 
 .priority-badge {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
+  width: 36px; height: 36px;
   background: var(--vp-c-brand);
-  color: white;
-  border-radius: 12px;
+  color: #fff;
+  border-radius: 9px;
   font-weight: 700;
-  font-size: 1rem;
-  box-shadow: 0 2px 8px rgba(19, 176, 238, 0.3);
-  border: 1px solid rgba(19, 176, 238, 0.2);
-}
-
-.priority-label {
-  font-size: 0.75rem;
-  color: var(--vp-c-text-2, #6b7280);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 500;
-}
-
-/* Server Section */
-.server-section {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
-.server-name {
-  font-family: var(--vp-font-family-mono, 'Courier New', monospace);
-  font-weight: 600;
-  color: var(--vp-c-text-1, #2d3748);
-  font-size: 1rem;
-  word-break: break-all;
-  line-height: 1.4;
-}
-
-.server-meta {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.server-type {
-  color: var(--vp-c-text-2, #6b7280);
   font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.server-status {
-  color: #22c55e;
-  font-size: 0.875rem;
-  font-weight: 600;
-}
-
-/* Summary Stats */
-.mx-summary-stats {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-top: 1px solid var(--vp-c-border-soft, #f1f5f9);
-}
-
-.stat-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 1rem;
-  text-align: center;
-  position: relative;
-}
-
-.stat-card:not(:last-child)::after {
-  content: '';
-  position: absolute;
-  right: 0;
-  top: 25%;
-  bottom: 25%;
-  width: 1px;
-  background: var(--vp-c-border-soft, #dee2e6);
-}
-
-.stat-number {
-  font-size: 1.75rem;
-  font-weight: 700;
-  color: var(--vp-c-brand);
-  line-height: 1;
-  margin-bottom: 0.25rem;
-}
-
-.stat-label {
-  font-size: 0.8rem;
-  color: var(--vp-c-text-2, #6b7280);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 500;
-}
-
-/* Result Sections */
-.section {
-  margin-top: 1.5rem;
-  padding: 1.25rem;
-  border-radius: 8px;
-}
-
-.section h4 {
-  margin: 0 0 1rem 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.section ul {
-  margin: 0;
-  padding-left: 1.5rem;
-}
-
-.section li {
-  margin: 0.5rem 0;
-  line-height: 1.5;
-}
-
-.analysis-section {
-  background: var(--vp-tip-soft, #f0f9ff);
-  border: 1px solid rgba(23, 162, 184, 0.18);
-}
-
-.analysis-section h4 {
-  color: var(--vp-c-tip-1, #17a2b8);
-}
-
-.analysis-grid {
-  display: grid;
-  gap: 1rem;
-}
-
-.analysis-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.75rem;
-  background: var(--vp-c-bg, #ffffff);
-  border-radius: 6px;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-}
-
-.analysis-item .label {
-  font-weight: 600;
-  color: var(--vp-c-text-1, #495057);
-}
-
-.analysis-item .value {
-  font-weight: 500;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  color: var(--vp-c-text-1, #374151);
-}
-
-/* Status dot, the single source of color */
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
   flex-shrink: 0;
+  box-shadow: 0 1px 4px hsla(197, 87%, 50%, 0.3);
 }
 
-.status-dot.pass { background: #16a34a; }
-.status-dot.warn { background: #d97706; }
-.status-dot.fail { background: #dc2626; }
-.status-dot.muted { background: var(--vp-c-text-3, #c3c8cf); }
+.mx-item-text { min-width: 0; }
+.mx-host { font-family: monospace; font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-1); word-break: break-all; }
+.mx-meta { font-size: 0.75rem; color: var(--vp-c-text-3, #9ca3af); margin-top: 0.1rem; }
 
-.warnings-section {
-  background: var(--vp-warning-soft, #fffbf0);
-  border: 1px solid rgba(214, 158, 46, 0.2);
+/* Alerts */
+.alert {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.875rem 1.125rem;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  font-size: 0.875rem;
+  line-height: 1.6;
 }
 
-.warnings-section h4 {
-  color: var(--vp-c-warning-1, #d69e2e);
-}
+.alert > svg { flex-shrink: 0; margin-top: 0.1rem; }
+.alert ul { margin: 0; padding-left: 1.1rem; }
+.alert li + li { margin-top: 0.2rem; }
 
-.recommendations-section {
-  background: var(--vp-tip-soft, #f0f9ff);
-  border: 1px solid rgba(23, 162, 184, 0.18);
-}
+.alert-warn { background: rgba(217,119,6,0.06); border-color: rgba(217,119,6,0.2); color: var(--vp-c-text-1); }
+.alert-warn > svg { color: #d97706; }
+.alert-tip  { background: hsla(197,87%,50%,0.05); border-color: hsla(197,87%,50%,0.2); color: var(--vp-c-text-1); }
+.alert-tip > svg { color: var(--vp-c-brand-dark, #0891b2); }
 
-.recommendations-section h4 {
-  color: var(--vp-c-tip-1, #17a2b8);
-}
-
-/* Dark Mode */
-@media (prefers-color-scheme: dark) {
-  .refresh-captcha-btn {
-    background: var(--vp-c-bg-soft);
-    border-color: var(--vp-c-border);
-    color: var(--vp-c-text-1);
-  }
-  
-  .refresh-captcha-btn:hover:not(:disabled) {
-    border-color: var(--vp-c-brand);
-  }
-  
-  .mx-records-container {
-    background: var(--vp-c-bg, #17181c);
-    border-color: #282a36;
-  }
-  
-  .mx-record-item {
-    border-color: #282a36;
-  }
-  
-  .server-name {
-    color: var(--vp-c-brand-light);
-  }
-  
-  .priority-badge {
-    background: var(--vp-c-brand) !important;
-    box-shadow: 0 2px 8px rgba(19, 176, 238, 0.3) !important;
-    border: 1px solid rgba(19, 176, 238, 0.2) !important;
-  }
-  
-  .mx-summary-stats {
-    background: #252736;
-    border-color: #282a36;
-  }
-  
-  .stat-card::after {
-    background: #282a36;
-  }
-  
-  .recommendations-section,
-  .recommendations-section ul,
-  .recommendations-section li {
-    color: #2d3748 !important;
-  }
-  
-  .info-tip-pop {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-    box-shadow: 0 8px 24px rgba(0,0,0,.3);
-  }
-  
-  .info-tip-pop::before {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-  }
-}
-
-@media (max-width: 480px) {
-  .info-tip-pop {
-    position: fixed;
-    left: 10px !important;
-    right: 10px !important;
-    top: auto !important;
-    bottom: 20px;
-    transform: none !important;
-    width: auto !important;
-    max-width: none !important;
-    z-index: 9999;
-  }
-  
-  .info-tip-pop::before {
-    display: none;
-  }
-  
-  .info-tip:hover .info-tip-pop,
-  .info-tip:focus .info-tip-pop {
-    transform: none !important;
-  }
-}
+/* Dark mode */
+.dark .hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.09) 0%, hsla(197,87%,50%,0.06) 100%); border-color: rgba(22,163,74,0.25); }
+.dark .hero-fail { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.22); }
+.dark .icon-pass { background: rgba(22,163,74,0.18); color: #4ade80; }
+.dark .icon-fail { background: rgba(220,38,38,0.18); color: #f87171; }
+.dark .score-strong, .dark .score-excellent { background: rgba(22,163,74,0.2); color: #4ade80; }
+.dark .score-good, .dark .score-medium      { background: rgba(217,119,6,0.2);  color: #fbbf24; }
+.dark .score-poor, .dark .score-weak        { background: rgba(220,38,38,0.2);  color: #f87171; }
+.dark .signal-strong .signal-icon { color: #4ade80; }
+.dark .signal-medium .signal-icon { color: #fbbf24; }
+.dark .signal-weak   .signal-icon { color: #f87171; }
+.dark .mx-item { background: var(--vp-c-bg-soft, #252736); border-color: var(--vp-c-border, #3a3d50); }
+.dark .alert-warn { background: rgba(217,119,6,0.1); border-color: rgba(217,119,6,0.25); }
+.dark .alert-tip  { background: hsla(197,87%,50%,0.08); border-color: hsla(197,87%,50%,0.25); }
+.dark .alert-tip > svg { color: var(--vp-c-brand-light); }
 
 /* Responsive */
-@media (max-width: 768px) {
-  .mx-checker {
-    padding: 0 0.5rem;
-  }
-  
-  .tool-form,
-  .result-section {
-    padding: 1rem;
-    margin: 1rem 0;
-  }
-  
-  .captcha-container {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  
-  .refresh-captcha-btn {
-    align-self: center;
-  }
-  
-  .mx-record-content {
-    grid-template-columns: 100px 1fr;
-    gap: 1rem;
-    padding: 1.25rem;
-  }
-  
-  .priority-badge {
-    width: 42px;
-    height: 42px;
-    font-size: 0.9rem;
-  }
-  
-  .server-name {
-    font-size: 0.9rem;
-  }
-  
-  .mx-summary-stats {
-    grid-template-columns: 1fr;
-  }
-  
-  .stat-card {
-    padding: 1rem;
-  }
-  
-  .stat-card:not(:last-child)::after {
-    display: none;
-  }
-  
-  .stat-card:not(:last-child) {
-    border-bottom: 1px solid var(--vp-c-border-soft, #dee2e6);
-  }
+@media (max-width: 640px) {
+  .search-form { flex-direction: column; align-items: stretch; }
+  .search-btn { width: 100%; }
+  .hero { padding: 1.25rem; gap: 1rem; }
+  .hero-score { align-self: flex-start; }
+  .signals-grid { grid-template-columns: repeat(3, 1fr); gap: 0.5rem; }
+  .signal { padding: 0.625rem; }
 }
 
-@media (max-width: 480px) {
-  .mx-record-content {
-    grid-template-columns: 1fr;
-    text-align: center;
-    gap: 1rem;
-    padding: 1rem;
-  }
-  
-  .priority-section {
-    flex-direction: row;
-    justify-content: center;
-  }
-  
-  .server-meta {
-    justify-content: center;
-  }
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .info-tip {
-    width: 1.25rem;
-    height: 1.25rem;
-    line-height: 1.25rem;
-  }
-  
-  .info-tip-pop {
-    padding: 1rem 1.25rem;
-    font-size: .875rem;
-  }
+@media (max-width: 400px) {
+  .signals-grid { grid-template-columns: 1fr; }
 }
 </style>
-

--- a/.vitepress/theme/free-tools/MxChecker.vue
+++ b/.vitepress/theme/free-tools/MxChecker.vue
@@ -19,26 +19,39 @@ const resultsRef = ref(null)
 const isFormDisabled = computed(() => loading.value)
 
 function hasUniquePriorities(records) {
-  if (!records?.length) return true
+  if (!records?.length) {
+    return true
+  }
   return new Set(records.map(r => r.priority)).size === records.length
 }
 
 const redundancySignal = computed(() => {
   const n = result.value?.records?.length ?? 0
-  if (n > 1) return { label: 'Multiple servers', level: 'strong', icon: 'check' }
-  if (n === 1) return { label: 'Single server', level: 'weak', icon: 'alert' }
+  if (n > 1) {
+    return { label: 'Multiple servers', level: 'strong', icon: 'check' }
+  }
+  if (n === 1) {
+    return { label: 'Single server', level: 'weak', icon: 'alert' }
+  }
   return { label: 'None', level: 'weak', icon: 'alert' }
 })
 
 const priorityShape = computed(() => {
-  if (!result.value?.records?.length) return { label: '—', level: 'muted', icon: 'dot' }
+  if (!result.value?.records?.length) {
+    return { label: '—', level: 'muted', icon: 'dot' }
+  }
   return hasUniquePriorities(result.value.records)
     ? { label: 'Unique priorities', level: 'strong', icon: 'check' }
     : { label: 'Duplicate priorities', level: 'medium', icon: 'minus' }
 })
 
-function onTurnstileVerified(token) { turnstileToken.value = token }
-function onTurnstileInvalid()       { turnstileToken.value = '' }
+function onTurnstileVerified(token) {
+  turnstileToken.value = token
+}
+
+function onTurnstileInvalid() {
+  turnstileToken.value = ''
+}
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -59,7 +72,10 @@ async function checkMxHandler() {
   errorMessage.value = ''
 
   try {
-    if (!validateInputs()) { loading.value = false; return }
+    if (!validateInputs()) {
+      loading.value = false
+      return
+    }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
@@ -82,7 +98,9 @@ async function checkMxHandler() {
     resetTurnstile()
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) resetTurnstile()
+    if (err.status === 401) {
+      resetTurnstile()
+    }
   } finally {
     loading.value = false
   }

--- a/.vitepress/theme/free-tools/MxChecker.vue
+++ b/.vitepress/theme/free-tools/MxChecker.vue
@@ -128,7 +128,7 @@ onMounted(async () => {
 
     <ToolSwitcher :domain="domain" />
 
-    <!-- ── Inline form ── -->
+    <!-- Inline form -->
     <div class="search-bar" :class="{ 'has-result': result }">
       <form class="search-form" @submit.prevent="checkMxHandler">
         <div class="search-input-wrap">
@@ -173,13 +173,13 @@ onMounted(async () => {
       />
     </div>
 
-    <!-- ── Error ── -->
+    <!-- Error -->
     <div v-if="errorMessage" class="error-pill">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
       {{ errorMessage }}
     </div>
 
-    <!-- ── Results ── -->
+    <!-- Results -->
     <div v-if="result" class="results" ref="resultsRef">
 
       <!-- Hero -->

--- a/.vitepress/theme/free-tools/MxChecker.vue
+++ b/.vitepress/theme/free-tools/MxChecker.vue
@@ -67,8 +67,8 @@ function validateInputs() {
 }
 
 async function checkMxHandler() {
-  result.value       = null
-  loading.value       = true
+  result.value = null
+  loading.value = true
   errorMessage.value = ''
 
   try {

--- a/.vitepress/theme/free-tools/MxChecker.vue
+++ b/.vitepress/theme/free-tools/MxChecker.vue
@@ -7,12 +7,12 @@ import Turnstile from './Turnstile.vue'
 import SignalIcon from './SignalIcon.vue'
 import ToolSwitcher from './ToolSwitcher.vue'
 
-const domain       = ref('')
-const loading      = ref(false)
-const result       = ref(null)
+const domain = ref('')
+const loading = ref(false)
+const result = ref(null)
 const errorMessage = ref('')
 
-const turnstileRef   = ref(null)
+const turnstileRef = ref(null)
 const turnstileToken = ref('')
 const resultsRef = ref(null)
 
@@ -87,10 +87,10 @@ async function checkMxHandler() {
     })
 
     result.value = {
-      valid:   true,
-      domain:  data.result.domain || domain.value,
+      valid: true,
+      domain: data.result.domain || domain.value,
       records: data.result.records || data.result.mxRecords || [],
-      score:   data.result.score,
+      score: data.result.score,
       warnings: data.result.warnings || [],
       recommendations: data.result.recommendations || [],
     }

--- a/.vitepress/theme/free-tools/SignalIcon.vue
+++ b/.vitepress/theme/free-tools/SignalIcon.vue
@@ -1,0 +1,12 @@
+<script setup>
+defineProps({
+  name: { type: String, required: true }, // 'check' | 'minus' | 'alert' | 'dot'
+})
+</script>
+
+<template>
+  <svg v-if="name === 'check'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+  <svg v-else-if="name === 'minus'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg>
+  <svg v-else-if="name === 'alert'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+  <svg v-else width="8" height="8" viewBox="0 0 8 8" fill="currentColor"><circle cx="4" cy="4" r="4"/></svg>
+</template>

--- a/.vitepress/theme/free-tools/SpfChecker.vue
+++ b/.vitepress/theme/free-tools/SpfChecker.vue
@@ -4,34 +4,45 @@ import { checkSpf } from '../../../connectors/bluefoxEmailToolsApi.js'
 import { isSessionValid } from '../../../connectors/turnstileSession.js'
 import { syncWithUrl, loadFromUrl } from './helpers/urlSync.js'
 import Turnstile from './Turnstile.vue'
+import SignalIcon from './SignalIcon.vue'
+import ToolSwitcher from './ToolSwitcher.vue'
 
-// ---- VARIABLES ----
-const domain = ref('')
-const testIp = ref('')
-const loading = ref(false)
-const result = ref(null)
+const domain       = ref('')
+const testIp       = ref('')
+const showIpField  = ref(false)
+const loading      = ref(false)
+const result       = ref(null)
 const errorMessage = ref('')
 
-// History for navigation
-const history = ref([])
+const history      = ref([])
 const currentIndex = ref(-1)
 
-// Turnstile state
-const turnstileRef = ref(null)
+const turnstileRef   = ref(null)
 const turnstileToken = ref('')
+const resultsRef = ref(null)
 
-const isFormDisabled = computed(() =>
-  loading.value
-)
+const isFormDisabled = computed(() => loading.value)
 
-// ---- FUNCTIONS ----
-function onTurnstileVerified(token) {
-  turnstileToken.value = token
-}
+const lookupSignal = computed(() => {
+  const n = result.value?.lookups
+  if (n == null) return null
+  if (n > 10) return { label: `${n} (exceeds 10)`, level: 'weak', icon: 'alert' }
+  if (n >= 8)  return { label: `${n} of 10`, level: 'medium', icon: 'minus' }
+  return { label: `${n} of 10`, level: 'strong', icon: 'check' }
+})
 
-function onTurnstileInvalid() {
-  turnstileToken.value = ''
-}
+const policySignal = computed(() => {
+  const p = result.value?.policy
+  if (!p) return null
+  if (p.includes('-all')) return { label: 'Hard fail (-all)', level: 'strong', icon: 'check' }
+  if (p.includes('~all')) return { label: 'Soft fail (~all)', level: 'medium', icon: 'minus' }
+  if (p.includes('?all')) return { label: 'Neutral (?all)', level: 'weak', icon: 'alert' }
+  if (p.includes('+all')) return { label: 'Allow all (+all)', level: 'weak', icon: 'alert' }
+  return { label: p, level: 'muted', icon: 'dot' }
+})
+
+function onTurnstileVerified(token) { turnstileToken.value = token }
+function onTurnstileInvalid()       { turnstileToken.value = '' }
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -43,12 +54,11 @@ function validateInputs() {
     errorMessage.value = 'Please enter a domain name'
     return false
   }
-
   return true
 }
 
 async function checkSpfHandler() {
-  result.value = null
+  result.value       = null
   errorMessage.value = ''
 
   domain.value = domain.value.trim()
@@ -58,27 +68,10 @@ async function checkSpfHandler() {
     history.value = history.value.slice(0, currentIndex.value + 1)
   }
 
-  if (result.value && domain.value) {
-    const currentState = {
-      domain: domain.value,
-      testIp: testIp.value,
-      result: result.value
-    }
-    if (history.value[currentIndex.value]?.domain !== domain.value) {
-      history.value.push(currentState)
-      currentIndex.value++
-    } else {
-      history.value[currentIndex.value].testIp = testIp.value
-    }
-  }
-
   loading.value = true
 
   try {
-    if (!validateInputs()) {
-      loading.value = false
-      return
-    }
+    if (!validateInputs()) { loading.value = false; return }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
@@ -87,22 +80,18 @@ async function checkSpfHandler() {
     const data = await checkSpf({
       domain: domain.value,
       turnstileToken: turnstileToken.value,
-      testIp: testIp.value.trim() || undefined
+      testIp: testIp.value.trim() || undefined,
     })
 
     result.value = {
-      valid: true,
-      domain: data.result.domain || domain.value,
-      record: data.result.rawRecord || data.result.record || 'Not found',
+      valid:   true,
+      domain:  data.result.domain || domain.value,
+      record:  data.result.rawRecord || data.result.record || 'Not found',
       lookups: data.result.lookups,
-      policy: data.result.policy,
+      policy:  data.result.policy,
       mechanisms: (data.result.mechanisms || []).map(m => {
         const match = m.original.toLowerCase().match(/^(include|redirect|a|mx):([^\s\/]+)/)
-        const targetDomain = match ? match[2] : null
-        return {
-          ...m,
-          targetDomain
-        }
+        return { ...m, targetDomain: match ? match[2] : null }
       }),
       warnings: data.result.warnings || [],
       recommendations: data.result.recommendations || [],
@@ -110,30 +99,23 @@ async function checkSpfHandler() {
       ipTestResult: data.result.ipTestResult ? {
         ip: data.result.ipTestResult.ip || testIp.value || 'Unknown',
         result: data.result.ipTestResult.result || 'Unknown',
-        explanation: data.result.ipTestResult.explanation || null
+        explanation: data.result.ipTestResult.explanation || null,
       } : null,
-      score: data.result.score
+      score: data.result.score,
     }
 
     resetTurnstile()
 
-    const finalState = {
-      domain: domain.value,
-      testIp: testIp.value,
-      result: result.value
-    }
+    const finalState = { domain: domain.value, testIp: testIp.value, result: result.value }
     if (currentIndex.value === -1 || history.value[currentIndex.value]?.domain !== domain.value) {
       history.value.push(finalState)
       currentIndex.value++
     } else {
       history.value[currentIndex.value] = finalState
     }
-
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) {
-      resetTurnstile()
-    }
+    if (err.status === 401) resetTurnstile()
   } finally {
     loading.value = false
   }
@@ -141,7 +123,6 @@ async function checkSpfHandler() {
 
 function goBack() {
   if (currentIndex.value <= 0) return
-
   const previous = history.value[currentIndex.value - 1]
   currentIndex.value--
   domain.value = previous.domain
@@ -160,7 +141,6 @@ function checkIncludedDomain(includedDomain) {
 
 function getIpResultClass(res) {
   const resultString = typeof res === 'string' ? res : (res?.result || res?.status?.result || res?.status || '')
-  
   switch (String(resultString).toLowerCase()) {
     case 'pass': return 'result-pass'
     case 'fail': return 'result-fail'
@@ -174,9 +154,7 @@ function getIpResultClass(res) {
 
 function getDisplayResult(res) {
   const resultString = typeof res === 'string' ? res : (res?.result || res?.status?.result || res?.status || '')
-  
   const normalized = String(resultString).toLowerCase()
-  
   switch (normalized) {
     case 'pass': return 'PASS'
     case 'fail': return 'FAIL'
@@ -188,144 +166,157 @@ function getDisplayResult(res) {
   }
 }
 
-// ---- WATCHES ----
-watch([domain, testIp], () => {
-  syncWithUrl({ domain: domain.value, testIp: testIp.value })
-})
+watch([domain, testIp], () => syncWithUrl({ domain: domain.value, testIp: testIp.value }))
 
-// ---- LIFECYCLE ----
 onMounted(async () => {
-  loadFromUrl({ domain, testIp })
+  const urlParams = new URLSearchParams(window.location.search)
 
+  loadFromUrl({ domain, testIp })
+  if (testIp.value) showIpField.value = true
   await nextTick()
+
+  if (urlParams.get('run') === '1' && domain.value) {
+    await turnstileRef.value?.whenReady()
+    await checkSpfHandler()
+    await nextTick()
+    resultsRef.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
 })
 </script>
 
 <template>
   <div class="spf-checker">
-    <div class="tool-form">
-      <form @submit.prevent="checkSpfHandler">
-        <!-- Domain Input -->
-        <div class="form-group">
-          <label for="domain">Domain:</label>
+
+    <ToolSwitcher :domain="domain" />
+
+    <!-- ── Inline form ── -->
+    <div class="search-bar" :class="{ 'has-result': result }">
+      <form class="search-form" @submit.prevent="checkSpfHandler">
+        <div class="search-input-wrap">
+          <span class="search-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+            </svg>
+          </span>
           <input
             id="domain"
             v-model="domain"
             type="text"
             placeholder="example.com"
             :disabled="loading"
+            autocomplete="off"
+            spellcheck="false"
             required
           />
+          <button
+            v-if="domain && !loading"
+            type="button"
+            class="search-clear"
+            aria-label="Clear domain"
+            @click="domain = ''"
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
         </div>
+        <Turnstile
+          ref="turnstileRef"
+          class="turnstile-inline"
+          :class="{ 'turnstile-collapsed': result }"
+          @verified="onTurnstileVerified"
+          @expired="onTurnstileInvalid"
+          @error="onTurnstileInvalid"
+        />
+        <button type="submit" class="search-btn" :disabled="isFormDisabled">
+          <span v-if="loading" class="btn-loading"><span class="spinner"></span></span>
+          <span v-else>Check SPF</span>
+        </button>
+      </form>
 
-        <!-- Optional IP Input -->
-        <div class="form-group">
-          <label for="testIp">Optional: Test SPF for a specific IP</label>
+      <!-- Optional IP test toggle -->
+      <div class="ip-toggle-row" v-if="!result || showIpField">
+        <button v-if="!showIpField" type="button" class="ip-toggle-btn" @click="showIpField = true">
+          + Test a specific IP against this record
+        </button>
+        <div v-else class="ip-field-wrap">
           <input
-            id="testIp"
             v-model="testIp"
             type="text"
+            class="ip-field"
             placeholder="e.g. 203.0.113.2"
             :disabled="loading"
             autocomplete="off"
           />
-          <small class="form-help">Leave blank to skip IP-based test.</small>
+          <button type="button" class="ip-field-clear" aria-label="Remove IP test" @click="testIp = ''; showIpField = false">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
         </div>
-
-        <!-- Verification -->
-        <div class="form-group">
-          <Turnstile
-            ref="turnstileRef"
-            @verified="onTurnstileVerified"
-            @expired="onTurnstileInvalid"
-            @error="onTurnstileInvalid"
-          />
-        </div>
-
-        <!-- Submit Button -->
-        <button type="submit" class="check-btn" :disabled="isFormDisabled">
-          <span v-if="loading" class="btn-loading">
-            <div class="loading-spinner"></div>
-            Checking...
-          </span>
-          <span v-else>Check SPF</span>
-        </button>
-      </form>
+      </div>
     </div>
 
-    <!-- Error Display -->
-    <div v-if="errorMessage" class="error-section">
-      <p class="error-message">{{ errorMessage }}</p>
+    <!-- ── Error ── -->
+    <div v-if="errorMessage" class="error-pill">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      {{ errorMessage }}
     </div>
 
-    <!-- Results -->
-    <div v-if="result" class="result-section">
-      <h3>SPF Check Results</h3>
+    <!-- ── Back nav ── -->
+    <div v-if="currentIndex > 0 && result" class="back-nav">
+      <button type="button" @click="goBack" class="back-btn">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg>
+        Back to "{{ history[currentIndex - 1]?.domain }}"
+      </button>
+    </div>
 
-      <!-- Status -->
-      <div class="status-box">
-        <p><strong>{{ result.valid ? 'SPF Record Found' : 'SPF Record Missing or Invalid' }}</strong></p>
-        <p v-if="result.score">
-          <strong>Security Score:</strong>
-          {{ result.score.value }}/{{ result.score.outOf }} ({{ result.score.level }})
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Heuristic score (0 to {{ result.score.outOf }}) indicating relative SPF robustness.</span>
-          </span>
-        </p>
+    <!-- ── Results ── -->
+    <div v-if="result" class="results" ref="resultsRef">
+
+      <!-- Hero -->
+      <div class="hero" :class="result.valid && result.record !== 'Not found' ? 'hero-pass' : 'hero-fail'">
+        <div class="hero-icon" :class="result.valid && result.record !== 'Not found' ? 'icon-pass' : 'icon-fail'">
+          <svg v-if="result.valid && result.record !== 'Not found'" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          <svg v-else width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </div>
+        <div class="hero-text">
+          <h2 class="hero-title">{{ result.record !== 'Not found' ? 'SPF Record Found' : 'SPF Record Missing' }}</h2>
+          <p class="hero-domain">{{ result.domain }}</p>
+        </div>
+        <div v-if="result.score" class="hero-score">
+          <span class="score-num">{{ result.score.value }}<span class="score-denom">/{{ result.score.outOf }}</span></span>
+          <span class="score-label" :class="'score-' + result.score.level?.toLowerCase()">{{ result.score.level }}</span>
+        </div>
       </div>
 
-      <!-- Basic Information -->
-      <div class="info-section">
-        <h4>
-          Basic Information
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Summary of the SPF record published for this domain.</span>
-          </span>
-        </h4>
-        <p><strong>Domain:</strong> {{ result.domain }}</p>
-        <p>
-          <strong>SPF Record:</strong> {{ result.record }}
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">The exact TXT string returned from DNS that begins with v=spf1.</span>
-          </span>
-        </p>
-        <p v-if="result.policy">
-          <strong>Policy:</strong> {{ result.policy }}
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">The final mechanism (-all, ~all, ?all) that decides how mail failing SPF is treated.</span>
-          </span>
-        </p>
-        <p v-if="result.lookups !== undefined">
-          <strong>DNS Lookups:</strong> {{ result.lookups }}
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">RFC 7208 allows at most 10 DNS lookups during SPF evaluation. Exceeding this causes permerror.</span>
-          </span>
-          <span v-if="result.lookups > 10" class="lookup-warning">(exceeds 10; SPF evaluation may fail)</span>
-        </p>
+      <!-- Signals grid -->
+      <div v-if="result.record !== 'Not found'" class="signals-grid">
+        <div v-if="policySignal" class="signal" :class="'signal-' + policySignal.level">
+          <span class="signal-icon"><SignalIcon :name="policySignal.icon" /></span>
+          <span class="signal-name">Policy</span>
+          <span class="signal-value">{{ policySignal.label }}</span>
+        </div>
+        <div v-if="lookupSignal" class="signal" :class="'signal-' + lookupSignal.level">
+          <span class="signal-icon"><SignalIcon :name="lookupSignal.icon" /></span>
+          <span class="signal-name">DNS Lookups</span>
+          <span class="signal-value">{{ lookupSignal.label }}</span>
+        </div>
+        <div class="signal signal-muted">
+          <span class="signal-icon"><SignalIcon name="dot" /></span>
+          <span class="signal-name">Mechanisms</span>
+          <span class="signal-value">{{ result.mechanisms?.length ?? 0 }}</span>
+        </div>
       </div>
 
+      <!-- IP test result -->
       <ClientOnly>
-        <div v-if="result.ipTestResult" class="section ip-test-compact">
-          <h4>
-            IP Test Result
-            <span class="info-tip" tabindex="0">
-              ?
-              <span class="info-tip-pop">Live SPF evaluation for the IP you entered. Useful for troubleshooting delivery issues.</span>
-            </span>
-          </h4>
-          <div class="ip-test-compact-card">
+        <div v-if="result.ipTestResult" class="card">
+          <h3 class="card-title">IP Test Result</h3>
+          <div class="ip-test-card">
             <div class="ip-test-info">
               <span class="ip-address">{{ result.ipTestResult.ip }}</span>
-              <span :class="['ip-result-compact', getIpResultClass(result.ipTestResult.result)]">
+              <span :class="['ip-result-pill', getIpResultClass(result.ipTestResult.result)]">
                 {{ getDisplayResult(result.ipTestResult.result) }}
               </span>
             </div>
-            <p v-if="result.ipTestResult.explanation" class="ip-explanation-compact">
+            <p v-if="result.ipTestResult.explanation" class="ip-explanation">
               {{ result.ipTestResult.explanation }}
             </p>
           </div>
@@ -333,825 +324,495 @@ onMounted(async () => {
       </ClientOnly>
 
       <!-- Mechanisms -->
-      <div v-if="result.mechanisms?.length" class="mechanisms-section">
-        <h4>
-          Mechanisms
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Each directive in the SPF record. 'DNS' means it triggers an extra DNS lookup.</span>
-          </span>
-        </h4>
+      <div v-if="result.mechanisms?.length" class="card">
+        <h3 class="card-title">Mechanisms</h3>
         <div class="mechanisms-list">
-          <div
-            v-for="m in result.mechanisms"
-            :key="m.original"
-            class="mechanism-item"
-          >
+          <div v-for="m in result.mechanisms" :key="m.original" class="mechanism-item">
             <span class="mechanism-text">
               <template v-if="m.type === 'include' && m.targetDomain">
                 include:
-                <a
-                  href="#"
-                  @click.prevent="checkIncludedDomain(m.targetDomain)"
-                  class="inline-link"
-                >
-                  {{ m.targetDomain }}
-                </a>
+                <a href="#" @click.prevent="checkIncludedDomain(m.targetDomain)" class="inline-link">{{ m.targetDomain }}</a>
               </template>
-              <template v-else>
-                {{ m.original }}
-              </template>
+              <template v-else>{{ m.original }}</template>
             </span>
-            <span
-              class="mechanism-type"
-              :class="{ 'requires-lookup': m.requiresLookup }"
-            >
+            <span class="mechanism-type" :class="{ 'requires-lookup': m.requiresLookup }">
               {{ m.type }}{{ m.requiresLookup ? ' (DNS)' : '' }}
             </span>
           </div>
         </div>
       </div>
 
-      <!-- Back Button -->
-      <div v-if="currentIndex > 0" class="back-nav">
-        <button type="button" @click="goBack" class="back-btn">
-          ← Back to "{{ history[currentIndex - 1]?.domain }}"
-        </button>
+      <!-- Alerts -->
+      <div v-if="result.warnings?.length" class="alert alert-warn">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <ul><li v-for="w in result.warnings" :key="w">{{ w }}</li></ul>
       </div>
 
-      <!-- Mailauth Results -->
-      <div v-if="result.mailauthResult" class="section mailauth-section">
-        <h4>
-          Mailauth
-          <span class="info-tip" tabindex="0">
-            ?
-            <span class="info-tip-pop">Validation result from the mailauth library. It confirms parser agreement with your record.</span>
-          </span>
-        </h4>
-        <p><strong>Status:</strong> {{ result.mailauthResult.status.result }}</p>
-        <pre v-if="result.mailauthResult.info" class="auth-info">{{ result.mailauthResult.info }}</pre>
+      <div v-if="result.recommendations?.length" class="alert alert-tip">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        <ul><li v-for="r in result.recommendations" :key="r">{{ r }}</li></ul>
       </div>
 
-      <!-- Warnings, Recommendations -->
-      <div v-if="result.warnings?.length" class="section warnings-section">
-        <h4>Warnings</h4>
-        <ul>
-          <li v-for="warning in result.warnings" :key="warning">{{ warning }}</li>
-        </ul>
+      <!-- Expert disclosures -->
+      <div class="disclosures">
+        <details class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">Raw SPF record</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <code class="raw-record">{{ result.record }}</code>
+          </div>
+        </details>
+
+        <details v-if="result.mailauthResult" class="disclosure">
+          <summary class="disclosure-trigger">
+            <span class="disclosure-label">Mailauth validation</span>
+            <svg class="disclosure-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </summary>
+          <div class="disclosure-body">
+            <p class="mailauth-status"><strong>Status:</strong> {{ result.mailauthResult.status.result }}</p>
+            <pre v-if="result.mailauthResult.info" class="auth-info">{{ result.mailauthResult.info }}</pre>
+          </div>
+        </details>
       </div>
 
-      <div v-if="result.recommendations?.length" class="section recommendations-section">
-        <h4>Recommendations</h4>
-        <ul>
-          <li v-for="rec in result.recommendations" :key="rec">{{ rec }}</li>
-        </ul>
-      </div>
     </div>
   </div>
 </template>
 
 <style scoped>
 .spf-checker {
-  max-width: 800px;
+  max-width: 720px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 1rem 3rem;
 }
 
-.tool-form {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 12px;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-}
+/* Search bar */
+.search-bar { margin: 2rem 0 1.5rem; transition: margin 0.2s; }
+.search-bar.has-result { margin: 0 0 1rem; }
 
-.form-group {
-  margin-bottom: 1.5rem;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 600;
-  color: var(--vp-c-text-1, #374151);
-  font-size: 0.9rem;
-}
-
-.form-group input {
-  width: 100%;
-  padding: 0.875rem 1rem;
-  border: 2px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 8px;
-  font-size: 1rem;
-  transition: border-color 0.2s ease;
-  box-sizing: border-box;
-  background: var(--vp-c-bg, #ffffff);
-  color: var(--vp-c-text-1, #374151);
-}
-
-.form-group input:focus {
-  outline: none;
-  border-color: var(--vp-c-brand);
-  box-shadow: 0 0 0 3px rgba(19, 176, 238, 0.1);
-}
-
-.form-group input:disabled {
-  background: var(--vp-c-bg-mute, #f1f5f9);
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.form-help {
-  display: block;
-  margin-top: 0.5rem;
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-style: italic;
-}
-
-/* CAPTCHA Styles */
-.captcha-expired-message {
-  background: #fff3cd;
-  border: 1px solid #ffc107;
-  color: #856404;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1rem;
-  font-size: 0.875rem;
-}
-
-.captcha-container {
+.search-form {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  flex-wrap: wrap;
 }
 
-.captcha-image-container {
+.search-input-wrap {
   flex: 1;
-  min-height: 50px;
+  min-width: 220px;
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
-  background: #ffffff;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 6px;
-  padding: 0.5rem;
 }
 
-.captcha-loading,
-.captcha-placeholder {
-  color: #6b7280;
-  font-style: italic;
-  text-align: center;
-}
-
-.load-captcha-btn {
-  background: var(--vp-c-brand);
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.875rem;
-  transition: background-color 0.2s ease;
-}
-
-.load-captcha-btn:hover {
-  background: var(--vp-c-brand-light);
-}
-
-.refresh-captcha-btn {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  padding: 0.5rem;
-  border-radius: 6px;
-  cursor: pointer;
-  width: 2.5rem;
-  height: 2.5rem;
+.search-icon {
+  position: absolute;
+  left: 0.875rem;
+  color: var(--vp-c-text-3, #9ca3af);
   display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
+  pointer-events: none;
 }
 
-.refresh-captcha-btn:hover:not(:disabled) {
-  background: var(--vp-c-bg, #ffffff);
-  border-color: var(--vp-c-brand);
-}
-
-.refresh-captcha-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.refresh-captcha-btn img {
-  width: 16px;
-  height: 16px;
-}
-
-.captcha-help {
-  display: block;
-  margin-top: 0.5rem;
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  font-style: italic;
-}
-
-/* Button - Using Theme Brand Colors */
-.check-btn {
-  background: var(--vp-c-brand);
-  color: #ffffff;
-  padding: 0.875rem 2rem;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 600;
-  transition: all 0.2s ease;
+.search-input-wrap input {
   width: 100%;
-  box-shadow: 0 2px 4px rgba(19, 176, 238, 0.2);
+  padding: 0.75rem 2.25rem 0.75rem 2.5rem;
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 10px;
+  font-size: 1rem;
+  background: var(--vp-c-bg, #fff);
+  color: var(--vp-c-text-1, #111827);
+  transition: border-color 0.15s, box-shadow 0.15s, padding 0.2s;
+  box-sizing: border-box;
 }
 
-.check-btn:hover:not(:disabled) {
-  background: var(--vp-c-brand-light);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(19, 176, 238, 0.25);
+.has-result .search-input-wrap input { padding-top: 0.5rem; padding-bottom: 0.5rem; font-size: 0.9rem; }
+
+.search-input-wrap input:focus {
+  outline: none;
+  border-color: var(--vp-c-brand);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
 }
 
-.check-btn:active:not(:disabled) {
-  background: var(--vp-c-brand-dark);
-  transform: translateY(0);
+.search-input-wrap input:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.search-clear {
+  position: absolute;
+  right: 0.625rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px; height: 20px;
+  border: none;
+  background: var(--vp-c-bg-mute, #f1f5f9);
+  color: var(--vp-c-text-2, #6b7280);
+  border-radius: 50%;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
 }
 
-.check-btn:disabled {
-  background: var(--vp-c-bg-mute, #9ca3af);
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
+.search-clear:hover { background: var(--vp-c-bg-soft, #e5e7eb); color: var(--vp-c-text-1, #111827); }
+
+.turnstile-inline {
+  flex-shrink: 0;
+  transition: opacity 0.2s, max-width 0.2s, max-height 0.2s, margin 0.2s;
+  overflow: hidden;
 }
 
-.btn-loading {
+.turnstile-inline.turnstile-collapsed {
+  opacity: 0; max-width: 0; max-height: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.search-btn {
+  padding: 0.75rem 1.5rem;
+  background: var(--vp-c-brand);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, transform 0.1s, box-shadow 0.15s, padding 0.2s;
+  box-shadow: 0 1px 4px hsla(197, 87%, 50%, 0.3);
+  min-width: 130px;
+}
+
+.has-result .search-btn { padding: 0.5rem 1.25rem; min-width: 100px; font-size: 0.825rem; }
+.search-btn:hover:not(:disabled) { background: var(--vp-c-brand-dark); transform: translateY(-1px); box-shadow: 0 4px 12px hsla(197, 87%, 50%, 0.35); }
+.search-btn:active:not(:disabled) { transform: translateY(0); }
+.search-btn:disabled { opacity: 0.55; cursor: not-allowed; box-shadow: none; }
+
+.btn-loading { display: flex; align-items: center; justify-content: center; }
+
+.spinner {
+  display: inline-block;
+  width: 14px; height: 14px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* IP toggle row */
+.ip-toggle-row { margin-top: 0.625rem; }
+
+.ip-toggle-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--vp-c-text-3, #9ca3af);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.ip-toggle-btn:hover { color: var(--vp-c-brand); }
+
+.ip-field-wrap {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  justify-content: center;
+  max-width: 320px;
 }
 
-.loading-spinner {
-  width: 12px;
-  height: 12px;
-  border: 1.5px solid rgba(255, 255, 255, 0.3);
-  border-top: 1.5px solid #ffffff;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-}
-
-/* Error Section */
-.error-section {
-  background: var(--vp-danger-soft, #f8d7da);
-  color: var(--vp-c-danger-1, #721c24);
-  padding: 1rem;
+.ip-field {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1.5px solid var(--vp-c-border, #e5e7eb);
   border-radius: 8px;
-  margin: 1rem 0;
-  border: 1px solid var(--vp-c-danger-2, #f5c6cb);
-}
-
-.error-message {
-  margin: 0;
-  font-weight: 500;
-}
-
-/* Results Section */
-.result-section {
-  margin: 2rem 0;
-  padding: 1.5rem;
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.result-section h3 {
-  margin: 0 0 1.5rem 0;
-  color: var(--vp-c-text-1, #1a202c);
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.status-box {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  padding: 1.25rem;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  border-radius: 8px;
-  margin-bottom: 1.5rem;
-}
-
-.status-box p {
-  margin: 0.5rem 0;
-  font-size: 1rem;
-}
-
-/* Info Section */
-.info-section {
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.info-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.info-section p {
-  margin: 0.75rem 0;
-  color: var(--vp-c-text-2, #4a5568);
-  line-height: 1.6;
-}
-
-/* Info tip styles - Using Brand Colors + Improved Responsive */
-.info-tip {
-  display: inline-block;
-  margin-left: .3rem;
-  width: 1rem;
-  height: 1rem;
-  line-height: 1rem;
-  text-align: center;
-  border-radius: 50%;
-  background: var(--vp-c-brand);
-  color: #fff;
-  font-size: .675rem;
-  cursor: help;
-  position: relative;
-  vertical-align: middle;
-}
-
-.info-tip-pop {
-  opacity: 0;
-  pointer-events: none;
-  position: absolute;
-  left: 50%;
-  top: calc(100% + 8px);
-  transform: translateX(-50%);
-  width: max-content;
-  max-width: min(300px, 90vw);
-  padding: .8rem 1rem;
-  border-radius: 8px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  box-shadow: 0 8px 24px rgba(0,0,0,.12);
-  color: var(--vp-c-text-1, #374151);
-  font-size: .825rem;
-  line-height: 1.5;
-  z-index: 1000;
-  transition: opacity .2s ease, transform .2s ease;
-  transform: translateX(-50%) translateY(-4px);
-  word-wrap: break-word;
-  hyphens: auto;
-}
-
-.info-tip-pop::before {
-  content: '';
-  position: absolute;
-  top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 12px;
-  height: 12px;
-  background: var(--vp-c-bg, #ffffff);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-  border-bottom: none;
-  border-right: none;
-  transform: translateX(-50%) rotate(45deg);
-}
-
-.info-tip:hover .info-tip-pop,
-.info-tip:focus .info-tip-pop {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
-
-.info-tip:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:last-child .info-tip-pop {
-  left: auto;
-  right: 0;
-  transform: translateX(0);
-}
-
-.info-tip:nth-last-child(-n+2) .info-tip-pop::before,
-.info-tip:last-child .info-tip-pop::before {
-  left: auto;
-  right: 1rem;
-  transform: translateX(0) rotate(45deg);
-}
-
-.info-tip:hover:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:focus:nth-last-child(-n+2) .info-tip-pop,
-.info-tip:hover:last-child .info-tip-pop,
-.info-tip:focus:last-child .info-tip-pop {
-  transform: translateX(0) translateY(0);
-}
-
-/* Lookup warning */
-.lookup-warning {
-  background: var(--vp-warning-soft, #fffbf0);
-  color: var(--vp-c-warning-1, #d69e2e);
-  padding: 0.5rem;
-  border-radius: 4px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  margin-left: 0.5rem;
-}
-
-/* Compact IP Test Container - Using Brand Colors */
-.ip-test-compact {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border: 1px solid rgba(19, 176, 238, 0.18);
-  margin-top: 1.5rem;
-}
-
-.ip-test-compact h4 {
-  color: var(--vp-c-brand);
-  margin-bottom: 0.75rem;
-}
-
-.ip-test-compact-card {
+  font-size: 0.85rem;
+  font-family: monospace;
   background: var(--vp-c-bg, #fff);
-  border: 1px solid var(--vp-c-border, #e5e7eb);
-  border-radius: 8px;
-  padding: 1rem;
-  margin: 0.5rem 0;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  color: var(--vp-c-text-1, #111827);
+  box-sizing: border-box;
 }
 
-.ip-test-info {
+.ip-field:focus {
+  outline: none;
+  border-color: var(--vp-c-brand);
+  box-shadow: 0 0 0 3px hsla(197, 87%, 50%, 0.12);
+}
+
+.ip-field-clear {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
+  justify-content: center;
+  width: 22px; height: 22px;
+  border: none;
+  background: var(--vp-c-bg-mute, #f1f5f9);
+  color: var(--vp-c-text-2, #6b7280);
+  border-radius: 50%;
+  cursor: pointer;
+  flex-shrink: 0;
 }
+
+.ip-field-clear:hover { background: var(--vp-c-bg-soft, #e5e7eb); }
+
+/* Error */
+.error-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid rgba(220,38,38,0.2);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+}
+
+/* Back nav */
+.back-nav { margin-bottom: 1rem; }
+
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--vp-c-bg-soft, #f8f9fa);
+  color: var(--vp-c-text-2, #6b7280);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  padding: 0.5rem 0.875rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.825rem;
+  font-weight: 500;
+  transition: all 0.15s;
+}
+
+.back-btn:hover { background: var(--vp-c-bg, #fff); color: var(--vp-c-brand); border-color: var(--vp-c-brand); }
+
+/* Results */
+.results { display: flex; flex-direction: column; gap: 0.875rem; }
+
+/* Hero */
+.hero {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  flex-wrap: wrap;
+}
+
+.hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.06) 0%, hsla(197,87%,50%,0.04) 100%); border-color: rgba(22,163,74,0.2); }
+.hero-fail { background: rgba(220,38,38,0.04); border-color: rgba(220,38,38,0.18); }
+
+.hero-icon { width: 52px; height: 52px; border-radius: 13px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.icon-pass { background: rgba(22,163,74,0.12); color: #16a34a; border: 1px solid rgba(22,163,74,0.2); }
+.icon-fail { background: rgba(220,38,38,0.1);  color: #dc2626; border: 1px solid rgba(220,38,38,0.15); }
+
+.hero-text { flex: 1; min-width: 0; }
+.hero-title { margin: 0 0 0.2rem; font-size: 1.25rem; font-weight: 700; color: var(--vp-c-text-1, #111827); }
+.hero-domain { margin: 0; font-size: 0.8rem; font-family: monospace; color: var(--vp-c-text-2, #6b7280); }
+
+.hero-score { display: flex; flex-direction: column; align-items: center; flex-shrink: 0; }
+.score-num { font-size: 1.6rem; font-weight: 800; color: var(--vp-c-text-1, #111827); line-height: 1; }
+.score-denom { font-size: 0.9rem; font-weight: 500; color: var(--vp-c-text-3, #9ca3af); }
+.score-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; padding: 0.15rem 0.5rem; border-radius: 999px; margin-top: 0.25rem; }
+
+.score-strong, .score-excellent { background: rgba(22,163,74,0.12); color: #15803d; }
+.score-good, .score-medium      { background: rgba(217,119,6,0.12);  color: #b45309; }
+.score-poor, .score-weak        { background: rgba(220,38,38,0.1);   color: #dc2626; }
+
+/* Signals grid */
+.signals-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.625rem; }
+
+.signal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.75rem 0.875rem;
+  border-radius: 10px;
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+  background: var(--vp-c-bg, #fff);
+}
+
+.signal-icon { display: inline-flex; align-items: center; }
+.signal-name { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--vp-c-text-2, #6b7280); }
+.signal-value { font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-1, #111827); }
+
+.signal-strong .signal-icon { color: #16a34a; }
+.signal-medium .signal-icon { color: #d97706; }
+.signal-weak   .signal-icon { color: #dc2626; }
+.signal-muted  .signal-icon { color: var(--vp-c-text-3, #9ca3af); }
+.signal-strong { border-color: rgba(22,163,74,0.25); }
+.signal-medium { border-color: rgba(217,119,6,0.25); }
+.signal-weak   { border-color: rgba(220,38,38,0.2); }
+
+/* Card */
+.card {
+  background: var(--vp-c-bg, #fff);
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+}
+
+.card-title {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-text-1, #374151);
+}
+
+/* IP test */
+.ip-test-card { display: flex; flex-direction: column; gap: 0.5rem; }
+.ip-test-info { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
 
 .ip-address {
   font-family: monospace;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: var(--vp-c-text-1, #374151);
   background: var(--vp-c-bg-soft, #f8f9fa);
   padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-}
-
-.ip-result-compact {
-  padding: 0.125rem 0.625rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-/* Compact result colors, soft status pills */
-.ip-result-compact.result-pass {
-  background: rgba(22, 163, 74, 0.1);
-  color: #15803d;
-}
-
-.ip-result-compact.result-fail {
-  background: rgba(220, 38, 38, 0.08);
-  color: #b91c1c;
-}
-
-.ip-result-compact.result-softfail {
-  background: rgba(217, 119, 6, 0.1);
-  color: #b45309;
-}
-
-.ip-result-compact.result-neutral {
-  background: var(--vp-c-bg-soft, #f3f4f6);
-  color: var(--vp-c-text-2, #6b7280);
+  border-radius: 6px;
   border: 1px solid var(--vp-c-border-soft, #e5e7eb);
 }
 
-.ip-result-compact.result-error {
-  background: rgba(220, 38, 38, 0.08);
-  color: #b91c1c;
-}
+.ip-result-pill { padding: 0.125rem 0.625rem; border-radius: 999px; font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
+.ip-result-pill.result-pass { background: rgba(22,163,74,0.1); color: #15803d; }
+.ip-result-pill.result-fail, .ip-result-pill.result-error { background: rgba(220,38,38,0.08); color: #b91c1c; }
+.ip-result-pill.result-softfail { background: rgba(217,119,6,0.1); color: #b45309; }
+.ip-result-pill.result-neutral, .ip-result-pill.result-unknown { background: var(--vp-c-bg-soft, #f3f4f6); color: var(--vp-c-text-2, #6b7280); border: 1px solid var(--vp-c-border-soft, #e5e7eb); }
 
-.ip-result-compact.result-unknown {
-  background: var(--vp-c-bg-soft, #f3f4f6);
-  color: var(--vp-c-text-2, #6b7280);
-  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
-}
+.ip-explanation { margin: 0; color: var(--vp-c-text-2, #6b7280); font-size: 0.85rem; line-height: 1.5; }
 
-.ip-explanation-compact {
-  margin: 0.5rem 0 0 0;
-  color: var(--vp-c-text-2, #6b7280);
-  font-size: 0.875rem;
-  line-height: 1.5;
-  font-style: italic;
-}
-
-/* Mechanisms Section */
-.mechanisms-section {
-  margin-top: 1.5rem;
-  border-top: 1px solid var(--vp-c-border-soft, #eee);
-  padding-top: 1.5rem;
-}
-
-.mechanisms-section h4 {
-  margin: 0 0 1rem 0;
-  color: var(--vp-c-text-1, #333);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.mechanisms-list {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  border-radius: 8px;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
-  padding: 0.75rem;
-}
+/* Mechanisms */
+.mechanisms-list { display: flex; flex-direction: column; gap: 0.375rem; }
 
 .mechanism-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 0;
-  border-bottom: 1px solid var(--vp-c-border-soft, #eee);
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft, #f8f9fa);
   font-family: monospace;
+  font-size: 0.85rem;
 }
 
-.mechanism-item:last-child {
-  border-bottom: none;
-}
-
-.mechanism-text {
-  font-weight: 600;
-  color: var(--vp-c-text-1, #374151);
-}
-
-.inline-link {
-  color: var(--vp-c-brand);
-  font-weight: 600;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-.inline-link:hover {
-  opacity: 0.8;
-}
+.mechanism-text { font-weight: 600; color: var(--vp-c-text-1, #374151); word-break: break-all; }
+.inline-link { color: var(--vp-c-brand); font-weight: 600; text-decoration: underline; cursor: pointer; }
+.inline-link:hover { opacity: 0.8; }
 
 .mechanism-type {
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   color: var(--vp-c-text-2, #6b7280);
-  background: var(--vp-c-bg, #ffffff);
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  border: 1px solid var(--vp-c-border-soft, #dee2e6);
+  background: var(--vp-c-bg, #fff);
+  padding: 0.2rem 0.5rem;
+  border-radius: 5px;
+  border: 1px solid var(--vp-c-border-soft, #e5e7eb);
+  flex-shrink: 0;
 }
 
-.mechanism-type.requires-lookup {
-  color: var(--vp-c-text-1, #374151);
-  font-weight: 600;
-}
+.mechanism-type.requires-lookup { color: var(--vp-c-text-1, #374151); font-weight: 700; }
 
-/* Back Button - Using Brand Colors */
-.back-nav {
-  margin: 1.5rem 0;
-  text-align: left;
-}
+/* Alerts */
+.alert { display: flex; gap: 0.75rem; padding: 0.875rem 1.125rem; border-radius: 10px; border: 1px solid transparent; font-size: 0.875rem; line-height: 1.6; }
+.alert > svg { flex-shrink: 0; margin-top: 0.1rem; }
+.alert ul { margin: 0; padding-left: 1.1rem; }
+.alert li + li { margin-top: 0.2rem; }
+.alert-warn { background: rgba(217,119,6,0.06); border-color: rgba(217,119,6,0.2); color: var(--vp-c-text-1); }
+.alert-warn > svg { color: #d97706; }
+.alert-tip { background: hsla(197,87%,50%,0.05); border-color: hsla(197,87%,50%,0.2); color: var(--vp-c-text-1); }
+.alert-tip > svg { color: var(--vp-c-brand-dark, #0891b2); }
 
-.back-btn {
-  background: var(--vp-c-bg-soft, #f8f9fa);
-  color: var(--vp-c-text-1, #374151);
+/* Disclosures */
+.disclosures { display: flex; flex-direction: column; gap: 0.5rem; }
+
+.disclosure {
+  background: var(--vp-c-bg, #fff);
   border: 1px solid var(--vp-c-border, #e5e7eb);
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 0.9rem;
-  font-weight: 500;
-  transition: all 0.2s ease;
-  display: inline-flex;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.disclosure-trigger {
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: space-between;
+  padding: 0.875rem 1.25rem;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
 }
 
-.back-btn:hover:not(:disabled) {
-  background: var(--vp-c-bg, #ffffff);
-  color: var(--vp-c-brand);
-  border-color: var(--vp-c-brand);
-}
+.disclosure-trigger::-webkit-details-marker { display: none; }
+.disclosure-trigger:hover { background: var(--vp-c-bg-soft, #f8f9fa); }
+.disclosure-label { font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-1, #374151); }
+.disclosure-chevron { color: var(--vp-c-text-3, #9ca3af); transition: transform 0.2s; }
+details[open] .disclosure-chevron { transform: rotate(180deg); }
+.disclosure-body { padding: 0 1.25rem 1.25rem; border-top: 1px solid var(--vp-c-border-soft, #f1f5f9); }
 
-.back-btn:active {
-  transform: translateY(1px);
-}
-
-/* Result Sections */
-.section {
-  margin-top: 1.5rem;
-  padding: 1.25rem;
+.raw-record {
+  display: block;
+  margin-top: 0.875rem;
+  padding: 0.875rem 1rem;
+  background: var(--vp-c-bg-soft, #f8f9fa);
   border-radius: 8px;
+  font-size: 0.8rem;
+  word-break: break-all;
+  color: var(--vp-c-text-1, #374151);
 }
 
-.section h4 {
-  margin: 0 0 1rem 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.section ul {
-  margin: 0;
-  padding-left: 1.5rem;
-}
-
-.section li {
-  margin: 0.5rem 0;
-  line-height: 1.5;
-}
-
-.warnings-section {
-  background: var(--vp-warning-soft, #fffbf0);
-  border: 1px solid rgba(214, 158, 46, 0.2);
-}
-
-.warnings-section h4 {
-  color: var(--vp-c-warning-1, #d69e2e);
-}
-
-.recommendations-section {
-  background: var(--vp-tip-soft, #f0f9ff);
-  border: 1px solid rgba(23, 162, 184, 0.18);
-}
-
-.recommendations-section h4 {
-  color: var(--vp-c-tip-1, #17a2b8);
-}
-
-/* Mailauth Section */
-.mailauth-section h4 {
-  color: var(--vp-c-text-1, #333);
-}
+.mailauth-status { margin: 0.875rem 0 0; font-size: 0.875rem; color: var(--vp-c-text-1); }
 
 .auth-info {
   background: var(--vp-c-bg-soft, #f8f9fa);
-  padding: 1rem;
-  border-radius: 6px;
+  padding: 0.875rem 1rem;
+  border-radius: 8px;
   overflow-x: auto;
-  font-size: 0.875rem;
-  margin: 1rem 0;
+  font-size: 0.8rem;
+  margin: 0.625rem 0 0;
 }
 
-/* Dark Mode */
-@media (prefers-color-scheme: dark) {
-  .refresh-captcha-btn {
-    background: var(--vp-c-bg-soft);
-    border-color: var(--vp-c-border);
-    color: var(--vp-c-text-1);
-  }
-  
-  .refresh-captcha-btn:hover:not(:disabled) {
-    border-color: var(--vp-c-brand);
-  }
-  
-  .back-btn {
-    background: #2d3748;
-    border-color: #4a5568;
-    color: #e2e8f0;
-  }
-  
-  .back-btn:hover {
-    background: #374151;
-    color: var(--vp-c-brand);
-    border-color: var(--vp-c-brand);
-  }
-  
-  .recommendations-section,
-  .recommendations-section ul,
-  .recommendations-section li {
-    color: #2d3748 !important;
-  }
-  
-  .ip-test-compact-card {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-  }
-
-  .ip-result-compact.result-pass {
-    background: rgba(22, 163, 74, 0.18);
-    color: #6ee787;
-  }
-
-  .ip-result-compact.result-fail,
-  .ip-result-compact.result-error {
-    background: rgba(220, 38, 38, 0.18);
-    color: #f1948a;
-  }
-
-  .ip-result-compact.result-softfail {
-    background: rgba(217, 119, 6, 0.18);
-    color: #fbbf24;
-  }
-
-  .ip-result-compact.result-neutral,
-  .ip-result-compact.result-unknown {
-    background: var(--vp-c-bg-mute, #2a2d3e);
-    border-color: var(--vp-c-border, #3a3d50);
-  }
-  
-  .info-tip-pop {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-    box-shadow: 0 8px 24px rgba(0,0,0,.3);
-  }
-  
-  .info-tip-pop::before {
-    background: var(--vp-c-bg-soft, #252736);
-    border-color: var(--vp-c-border, #404040);
-  }
-}
-
-@media (max-width: 480px) {
-  .info-tip-pop {
-    position: fixed;
-    left: 10px !important;
-    right: 10px !important;
-    top: auto !important;
-    bottom: 20px;
-    transform: none !important;
-    width: auto !important;
-    max-width: none !important;
-    z-index: 9999;
-  }
-  
-  .info-tip-pop::before {
-    display: none;
-  }
-  
-  .info-tip:hover .info-tip-pop,
-  .info-tip:focus .info-tip-pop {
-    transform: none !important;
-  }
-}
+/* Dark mode */
+.dark .hero-pass { background: linear-gradient(135deg, rgba(22,163,74,0.09) 0%, hsla(197,87%,50%,0.06) 100%); border-color: rgba(22,163,74,0.25); }
+.dark .hero-fail { background: rgba(220,38,38,0.08); border-color: rgba(220,38,38,0.22); }
+.dark .icon-pass { background: rgba(22,163,74,0.18); color: #4ade80; }
+.dark .icon-fail { background: rgba(220,38,38,0.18); color: #f87171; }
+.dark .score-strong, .dark .score-excellent { background: rgba(22,163,74,0.2); color: #4ade80; }
+.dark .score-good, .dark .score-medium      { background: rgba(217,119,6,0.2);  color: #fbbf24; }
+.dark .score-poor, .dark .score-weak        { background: rgba(220,38,38,0.2);  color: #f87171; }
+.dark .signal-strong .signal-icon { color: #4ade80; }
+.dark .signal-medium .signal-icon { color: #fbbf24; }
+.dark .signal-weak   .signal-icon { color: #f87171; }
+.dark .mechanism-item { background: var(--vp-c-bg-soft, #252736); border-color: var(--vp-c-border, #3a3d50); }
+.dark .alert-warn { background: rgba(217,119,6,0.1); border-color: rgba(217,119,6,0.25); }
+.dark .alert-tip  { background: hsla(197,87%,50%,0.08); border-color: hsla(197,87%,50%,0.25); }
+.dark .alert-tip > svg { color: var(--vp-c-brand-light); }
+.dark .back-btn { background: var(--vp-c-bg-soft, #252736); border-color: var(--vp-c-border, #3a3d50); color: var(--vp-c-text-2); }
+.dark .ip-result-pill.result-pass { background: rgba(22,163,74,0.18); color: #6ee787; }
+.dark .ip-result-pill.result-fail, .dark .ip-result-pill.result-error { background: rgba(220,38,38,0.18); color: #f1948a; }
+.dark .ip-result-pill.result-softfail { background: rgba(217,119,6,0.18); color: #fbbf24; }
+.dark .ip-result-pill.result-neutral, .dark .ip-result-pill.result-unknown { background: var(--vp-c-bg-mute, #2a2d3e); border-color: var(--vp-c-border, #3a3d50); }
 
 /* Responsive */
-@media (max-width: 768px) {
-  .spf-checker {
-    padding: 0 0.5rem;
-  }
-  
-  .tool-form,
-  .result-section {
-    padding: 1rem;
-    margin: 1rem 0;
-  }
-  
-  .captcha-container {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  
-  .refresh-captcha-btn {
-    align-self: center;
-  }
-  
-  .back-btn {
-    font-size: 0.85rem;
-    padding: 0.6rem 1rem;
-  }
-  
-  .ip-test-info {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-  
-  .ip-address {
-    font-size: 0.85rem;
-  }
-  
-  .ip-result-compact {
-    font-size: 0.8rem;
-    padding: 0.35rem 0.7rem;
-  }
+@media (max-width: 640px) {
+  .search-form { flex-direction: column; align-items: stretch; }
+  .search-btn { width: 100%; }
+  .hero { padding: 1.25rem; gap: 1rem; }
+  .hero-score { align-self: flex-start; }
+  .signals-grid { grid-template-columns: repeat(3, 1fr); gap: 0.5rem; }
+  .signal { padding: 0.625rem; }
+  .mechanism-item { flex-direction: column; align-items: flex-start; gap: 0.375rem; }
 }
 
-@media (hover: none) and (pointer: coarse) {
-  .info-tip {
-    width: 1.25rem;
-    height: 1.25rem;
-    line-height: 1.25rem;
-  }
-  
-  .info-tip-pop {
-    padding: 1rem 1.25rem;
-    font-size: .875rem;
-  }
+@media (max-width: 400px) {
+  .signals-grid { grid-template-columns: 1fr; }
 }
 </style>

--- a/.vitepress/theme/free-tools/SpfChecker.vue
+++ b/.vitepress/theme/free-tools/SpfChecker.vue
@@ -218,19 +218,20 @@ onMounted(async () => {
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
-        <Turnstile
-          ref="turnstileRef"
-          class="turnstile-inline"
-          :class="{ 'turnstile-collapsed': result }"
-          @verified="onTurnstileVerified"
-          @expired="onTurnstileInvalid"
-          @error="onTurnstileInvalid"
-        />
         <button type="submit" class="search-btn" :disabled="isFormDisabled">
           <span v-if="loading" class="btn-loading"><span class="spinner"></span></span>
           <span v-else>Check SPF</span>
         </button>
       </form>
+
+      <Turnstile
+        ref="turnstileRef"
+        class="turnstile-row"
+        :class="{ 'turnstile-collapsed': result }"
+        @verified="onTurnstileVerified"
+        @expired="onTurnstileInvalid"
+        @error="onTurnstileInvalid"
+      />
 
       <!-- Optional IP test toggle -->
       <div class="ip-toggle-row" v-if="!result || showIpField">
@@ -307,7 +308,7 @@ onMounted(async () => {
 
       <!-- IP test result -->
       <ClientOnly>
-        <div v-if="result.ipTestResult" class="card">
+        <div v-if="result.ipTestResult" class="tool-card">
           <h3 class="card-title">IP Test Result</h3>
           <div class="ip-test-card">
             <div class="ip-test-info">
@@ -324,7 +325,7 @@ onMounted(async () => {
       </ClientOnly>
 
       <!-- Mechanisms -->
-      <div v-if="result.mechanisms?.length" class="card">
+      <div v-if="result.mechanisms?.length" class="tool-card">
         <h3 class="card-title">Mechanisms</h3>
         <div class="mechanisms-list">
           <div v-for="m in result.mechanisms" :key="m.original" class="mechanism-item">
@@ -455,14 +456,16 @@ onMounted(async () => {
 
 .search-clear:hover { background: var(--vp-c-bg-soft, #e5e7eb); color: var(--vp-c-text-1, #111827); }
 
-.turnstile-inline {
-  flex-shrink: 0;
-  transition: opacity 0.2s, max-width 0.2s, max-height 0.2s, margin 0.2s;
+.turnstile-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.75rem;
+  transition: opacity 0.2s, max-height 0.2s, margin 0.2s;
   overflow: hidden;
 }
 
-.turnstile-inline.turnstile-collapsed {
-  opacity: 0; max-width: 0; max-height: 0;
+.turnstile-row.turnstile-collapsed {
+  opacity: 0; max-height: 0; margin-top: 0;
   pointer-events: none;
   position: absolute;
 }
@@ -651,7 +654,7 @@ onMounted(async () => {
 .signal-weak   { border-color: rgba(220,38,38,0.2); }
 
 /* Card */
-.card {
+.tool-card {
   background: var(--vp-c-bg, #fff);
   border: 1px solid var(--vp-c-border, #e5e7eb);
   border-radius: 12px;

--- a/.vitepress/theme/free-tools/SpfChecker.vue
+++ b/.vitepress/theme/free-tools/SpfChecker.vue
@@ -7,17 +7,17 @@ import Turnstile from './Turnstile.vue'
 import SignalIcon from './SignalIcon.vue'
 import ToolSwitcher from './ToolSwitcher.vue'
 
-const domain       = ref('')
-const testIp       = ref('')
-const showIpField  = ref(false)
-const loading      = ref(false)
-const result       = ref(null)
+const domain = ref('')
+const testIp = ref('')
+const showIpField = ref(false)
+const loading = ref(false)
+const result = ref(null)
 const errorMessage = ref('')
 
-const history      = ref([])
+const history = ref([])
 const currentIndex = ref(-1)
 
-const turnstileRef   = ref(null)
+const turnstileRef = ref(null)
 const turnstileToken = ref('')
 const resultsRef = ref(null)
 
@@ -108,11 +108,11 @@ async function checkSpfHandler() {
     })
 
     result.value = {
-      valid:   true,
-      domain:  data.result.domain || domain.value,
-      record:  data.result.rawRecord || data.result.record || 'Not found',
+      valid: true,
+      domain: data.result.domain || domain.value,
+      record: data.result.rawRecord || data.result.record || 'Not found',
       lookups: data.result.lookups,
-      policy:  data.result.policy,
+      policy: data.result.policy,
       mechanisms: (data.result.mechanisms || []).map(m => {
         const match = m.original.toLowerCase().match(/^(include|redirect|a|mx):([^\s\/]+)/)
         return { ...m, targetDomain: match ? match[2] : null }

--- a/.vitepress/theme/free-tools/SpfChecker.vue
+++ b/.vitepress/theme/free-tools/SpfChecker.vue
@@ -25,24 +25,45 @@ const isFormDisabled = computed(() => loading.value)
 
 const lookupSignal = computed(() => {
   const n = result.value?.lookups
-  if (n == null) return null
-  if (n > 10) return { label: `${n} (exceeds 10)`, level: 'weak', icon: 'alert' }
-  if (n >= 8)  return { label: `${n} of 10`, level: 'medium', icon: 'minus' }
+  if (n == null) {
+    return null
+  }
+  if (n > 10) {
+    return { label: `${n} (exceeds 10)`, level: 'weak', icon: 'alert' }
+  }
+  if (n >= 8) {
+    return { label: `${n} of 10`, level: 'medium', icon: 'minus' }
+  }
   return { label: `${n} of 10`, level: 'strong', icon: 'check' }
 })
 
 const policySignal = computed(() => {
   const p = result.value?.policy
-  if (!p) return null
-  if (p.includes('-all')) return { label: 'Hard fail (-all)', level: 'strong', icon: 'check' }
-  if (p.includes('~all')) return { label: 'Soft fail (~all)', level: 'medium', icon: 'minus' }
-  if (p.includes('?all')) return { label: 'Neutral (?all)', level: 'weak', icon: 'alert' }
-  if (p.includes('+all')) return { label: 'Allow all (+all)', level: 'weak', icon: 'alert' }
+  if (!p) {
+    return null
+  }
+  if (p.includes('-all')) {
+    return { label: 'Hard fail (-all)', level: 'strong', icon: 'check' }
+  }
+  if (p.includes('~all')) {
+    return { label: 'Soft fail (~all)', level: 'medium', icon: 'minus' }
+  }
+  if (p.includes('?all')) {
+    return { label: 'Neutral (?all)', level: 'weak', icon: 'alert' }
+  }
+  if (p.includes('+all')) {
+    return { label: 'Allow all (+all)', level: 'weak', icon: 'alert' }
+  }
   return { label: p, level: 'muted', icon: 'dot' }
 })
 
-function onTurnstileVerified(token) { turnstileToken.value = token }
-function onTurnstileInvalid()       { turnstileToken.value = '' }
+function onTurnstileVerified(token) {
+  turnstileToken.value = token
+}
+
+function onTurnstileInvalid() {
+  turnstileToken.value = ''
+}
 
 function resetTurnstile() {
   turnstileToken.value = ''
@@ -71,7 +92,10 @@ async function checkSpfHandler() {
   loading.value = true
 
   try {
-    if (!validateInputs()) { loading.value = false; return }
+    if (!validateInputs()) {
+      loading.value = false
+      return
+    }
 
     if (!isSessionValid()) {
       turnstileToken.value = await turnstileRef.value.getToken()
@@ -115,14 +139,18 @@ async function checkSpfHandler() {
     }
   } catch (err) {
     errorMessage.value = err.message || 'Network error. Please try again.'
-    if (err.status === 401) resetTurnstile()
+    if (err.status === 401) {
+      resetTurnstile()
+    }
   } finally {
     loading.value = false
   }
 }
 
 function goBack() {
-  if (currentIndex.value <= 0) return
+  if (currentIndex.value <= 0) {
+    return
+  }
   const previous = history.value[currentIndex.value - 1]
   currentIndex.value--
   domain.value = previous.domain
@@ -172,7 +200,9 @@ onMounted(async () => {
   const urlParams = new URLSearchParams(window.location.search)
 
   loadFromUrl({ domain, testIp })
-  if (testIp.value) showIpField.value = true
+  if (testIp.value) {
+    showIpField.value = true
+  }
   await nextTick()
 
   if (urlParams.get('run') === '1' && domain.value) {

--- a/.vitepress/theme/free-tools/SpfChecker.vue
+++ b/.vitepress/theme/free-tools/SpfChecker.vue
@@ -79,7 +79,7 @@ function validateInputs() {
 }
 
 async function checkSpfHandler() {
-  result.value       = null
+  result.value = null
   errorMessage.value = ''
 
   domain.value = domain.value.trim()

--- a/.vitepress/theme/free-tools/SpfChecker.vue
+++ b/.vitepress/theme/free-tools/SpfChecker.vue
@@ -219,7 +219,7 @@ onMounted(async () => {
 
     <ToolSwitcher :domain="domain" />
 
-    <!-- ── Inline form ── -->
+    <!-- Inline form -->
     <div class="search-bar" :class="{ 'has-result': result }">
       <form class="search-form" @submit.prevent="checkSpfHandler">
         <div class="search-input-wrap">
@@ -284,13 +284,13 @@ onMounted(async () => {
       </div>
     </div>
 
-    <!-- ── Error ── -->
+    <!-- Error -->
     <div v-if="errorMessage" class="error-pill">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
       {{ errorMessage }}
     </div>
 
-    <!-- ── Back nav ── -->
+    <!-- Back nav -->
     <div v-if="currentIndex > 0 && result" class="back-nav">
       <button type="button" @click="goBack" class="back-btn">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="15 18 9 12 15 6"/></svg>
@@ -298,7 +298,7 @@ onMounted(async () => {
       </button>
     </div>
 
-    <!-- ── Results ── -->
+    <!-- Results -->
     <div v-if="result" class="results" ref="resultsRef">
 
       <!-- Hero -->

--- a/.vitepress/theme/free-tools/ToolSwitcher.vue
+++ b/.vitepress/theme/free-tools/ToolSwitcher.vue
@@ -1,0 +1,78 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute } from 'vitepress'
+
+const props = defineProps({
+  domain: { type: String, default: '' },
+})
+
+const TOOLS = [
+  { key: 'dmarc', label: 'DMARC', path: '/tools/deliverability/dmarc-checker' },
+  { key: 'spf',   label: 'SPF',   path: '/tools/deliverability/spf-checker' },
+  { key: 'dkim',  label: 'DKIM',  path: '/tools/deliverability/dkim-checker' },
+  { key: 'mx',    label: 'MX',    path: '/tools/deliverability/mx-checker' },
+]
+
+const route = useRoute()
+
+const items = computed(() => {
+  const cleanDomain = props.domain?.trim()
+  return TOOLS.map(tool => {
+    const active = route.path.replace(/\.html$/, '').endsWith(tool.path)
+    let href = tool.path
+    if (cleanDomain) {
+      const params = new URLSearchParams({ domain: cleanDomain, run: '1' })
+      if (tool.key === 'dkim') params.set('selector', 'google')
+      href = `${tool.path}?${params.toString()}`
+    }
+    return { ...tool, active, href }
+  })
+})
+</script>
+
+<template>
+  <nav class="tool-switcher" aria-label="Switch email diagnostic tool">
+    <a
+      v-for="item in items"
+      :key="item.key"
+      :href="item.href"
+      class="switcher-pill"
+      :class="{ active: item.active }"
+      :aria-current="item.active ? 'page' : undefined"
+    >
+      {{ item.label }}
+    </a>
+  </nav>
+</template>
+
+<style scoped>
+.tool-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 0 1.5rem;
+}
+
+.switcher-pill {
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--vp-c-border, #e5e7eb);
+  background: var(--vp-c-bg, #fff);
+  color: var(--vp-c-text-2, #6b7280);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none !important;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.switcher-pill:hover {
+  border-color: var(--vp-c-brand);
+  color: var(--vp-c-brand);
+}
+
+.switcher-pill.active {
+  background: var(--vp-c-brand);
+  border-color: var(--vp-c-brand);
+  color: #fff;
+}
+</style>

--- a/.vitepress/theme/free-tools/ToolSwitcher.vue
+++ b/.vitepress/theme/free-tools/ToolSwitcher.vue
@@ -8,9 +8,9 @@ const props = defineProps({
 
 const TOOLS = [
   { key: 'dmarc', label: 'DMARC', path: '/tools/deliverability/dmarc-checker' },
-  { key: 'spf',   label: 'SPF',   path: '/tools/deliverability/spf-checker' },
-  { key: 'dkim',  label: 'DKIM',  path: '/tools/deliverability/dkim-checker' },
-  { key: 'mx',    label: 'MX',    path: '/tools/deliverability/mx-checker' },
+  { key: 'spf', label: 'SPF', path: '/tools/deliverability/spf-checker' },
+  { key: 'dkim', label: 'DKIM', path: '/tools/deliverability/dkim-checker' },
+  { key: 'mx', label: 'MX', path: '/tools/deliverability/mx-checker' },
 ]
 
 const route = useRoute()

--- a/.vitepress/theme/free-tools/ToolSwitcher.vue
+++ b/.vitepress/theme/free-tools/ToolSwitcher.vue
@@ -22,7 +22,9 @@ const items = computed(() => {
     let href = tool.path
     if (cleanDomain) {
       const params = new URLSearchParams({ domain: cleanDomain, run: '1' })
-      if (tool.key === 'dkim') params.set('selector', 'google')
+      if (tool.key === 'dkim') {
+        params.set('selector', 'google')
+      }
       href = `${tool.path}?${params.toString()}`
     }
     return { ...tool, active, href }

--- a/.vitepress/theme/free-tools/Turnstile.vue
+++ b/.vitepress/theme/free-tools/Turnstile.vue
@@ -11,6 +11,12 @@ let widgetId = null
 let tokenResolve = null
 let tokenReject = null
 
+let readyResolve = null
+const readyPromise = new Promise((resolve) => { readyResolve = resolve })
+function whenReady() {
+  return readyPromise
+}
+
 function loadScript() {
   return new Promise((resolve, reject) => {
     if (window.turnstile) {
@@ -73,7 +79,7 @@ function getToken() {
   })
 }
 
-defineExpose({ reset, getToken })
+defineExpose({ reset, getToken, whenReady })
 
 onMounted(async () => {
   if (!SITE_KEY) {
@@ -105,6 +111,7 @@ onMounted(async () => {
         }
       }
     })
+    readyResolve()
   } catch (err) {
     console.error('Failed to render Turnstile widget:', err)
     emit('error')

--- a/scripts/purgecss.mjs
+++ b/scripts/purgecss.mjs
@@ -48,6 +48,30 @@ const result = await new PurgeCSS().purge({
       'dark',
       /^fade-/,      // Vue transition classes
       /^slide-/,
+      // free-tools result UI: only ever rendered client-side after a check
+      // completes, so it never appears in the prerendered HTML PurgeCSS scans.
+      /^search-/,
+      /^hero/,
+      /^icon-/,
+      /^score-/,
+      /^signal/,
+      /^alert/,
+      /^disclosure/,
+      /^tag-/,
+      /^td-/,
+      /^card/,
+      /^mechanism/,
+      /^ip-/,
+      /^error-pill/,
+      /^selector-/,
+      /^turnstile-/,
+      /^form-hint/,
+      /^switcher-/,
+      /^tool-switcher/,
+      /^results$/,
+      /^btn-loading$/,
+      /^spinner$/,
+      /^inline-link$/,
     ],
     deep: [
       /data-v-/,     // Vue scoped style selectors

--- a/tools/content/index.md
+++ b/tools/content/index.md
@@ -39,12 +39,23 @@ head:
       content: https://bluefox.email/assets/free-content-tools.png
 ---
 
+<script setup>
+import ToolsCategoryGrid from '../../.vitepress/theme/ToolsCategoryGrid.vue'
+
+const tools = [
+  {
+    name: 'Link Checker',
+    desc: 'Test every URL in your HTML email templates to catch broken links, bad redirects, and preview content before sending.',
+    href: '/tools/content/link-checker',
+    iconPaths: `<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>`,
+  },
+]
+</script>
+
 <GlossaryNavigation link="/tools" label="Back to Tools Home" />
 
 # Free Email Content Tools
 
-### Link Checker
+Make sure your email content is optimized for deliverability and engagement before you hit send.
 
-Ensure every link in your emails works perfectly. Test all URLs in your HTML email templates to catch broken links, validate redirects, and preview your content before sending to subscribers.
-
-[Read More →](/tools/content/link-checker)
+<ToolsCategoryGrid :tools="tools" />

--- a/tools/deliverability/index.md
+++ b/tools/deliverability/index.md
@@ -39,38 +39,48 @@ head:
       content: https://bluefox.email/assets/free-deliverability-tools.png
 ---
 
+<script setup>
+import ToolsCategoryGrid from '../../.vitepress/theme/ToolsCategoryGrid.vue'
+
+const tools = [
+  {
+    name: 'DMARC Checker',
+    desc: 'Validate your DMARC policy, check alignment mode and enforcement, and prevent email spoofing.',
+    href: '/tools/deliverability/dmarc-checker',
+    iconPaths: `<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/>`,
+  },
+  {
+    name: 'SPF Checker',
+    desc: 'Verify your SPF record, mechanisms, and DNS lookup count against the RFC 7208 10-lookup limit.',
+    href: '/tools/deliverability/spf-checker',
+    iconPaths: `<circle cx="12" cy="12" r="10"/><polyline points="9 12 11 14 15 10"/>`,
+  },
+  {
+    name: 'DKIM Checker',
+    desc: 'Test DKIM signatures for a domain and selector, and inspect key type, length, and tags.',
+    href: '/tools/deliverability/dkim-checker',
+    iconPaths: `<rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>`,
+  },
+  {
+    name: 'MX Record Checker',
+    desc: "Look up your domain's mail exchange records, priorities, and redundancy.",
+    href: '/tools/deliverability/mx-checker',
+    iconPaths: `<rect x="2.5" y="5" width="19" height="14" rx="2.5"/><path d="M3 7l9 6 9-6"/>`,
+  },
+  {
+    name: 'DMARC Report Analyzer',
+    desc: 'Upload a DMARC aggregate report to see pass rates, sources, and authentication breakdowns.',
+    href: '/tools/deliverability/dmarc-report-analyzer',
+    tag: 'Upload',
+    iconPaths: `<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>`,
+  },
+]
+</script>
+
 <GlossaryNavigation link="/tools" label="Back to Tools Home" />
 
 # Free Email Deliverability Tools
 
 Boost your email deliverability with our comprehensive collection of **free [email authentication](/email-sending-concepts/email-authentication) tools**. These professional-grade utilities help you validate, analyze, and optimize your email infrastructure for maximum inbox placement and security.
 
-### DMARC Checker
-**Validate your DMARC policy and prevent email spoofing**. Check if your domain has proper [DMARC](/email-sending-concepts/dmarc) records configured and analyze policy effectiveness for email authentication. Our DMARC checker helps ensure your domain is protected against phishing attacks and improves email deliverability.
-
-[Read More →](/tools/deliverability/dmarc-checker)
-
-
-### SPF Checker  
-**Verify your [SPF](/email-sending-concepts/spf) records and authorize legitimate senders**. Ensure your Sender Policy Framework is correctly configured to prevent email spoofing and improve inbox placement. Check DNS syntax, validate authorized servers, and optimize your SPF configuration.
-
-[Read More →](/tools/deliverability/spf-checker)
-
-
-### DKIM Checker
-**Test [DKIM](/email-sending-concepts/dkim) signatures and email authentication**. Verify that your DomainKeys Identified Mail signatures are properly configured and discoverable by receiving email servers. Ensure email integrity and build sender reputation with proper DKIM validation.
-
-[Read More →](/tools/deliverability/dkim-checker)
-
-
-### MX Record Checker
-**Lookup and analyze [mail exchange](/email-sending-concepts/mx-record) records**. Check your domain's MX records to ensure proper email routing and identify potential delivery issues. Verify mail server configuration and test [SMTP](/email-sending-concepts/smtp) connectivity for reliable email delivery.
-
-[Read More →](/tools/deliverability/mx-checker)
-
-
-### DMARC Report Analyzer
-**Analyze DMARC aggregate reports for security insights**. Upload and parse your DMARC reports to gain visibility into email authentication performance, identify unauthorized usage, and optimize your email security posture.
-
-[Read More →](/tools/deliverability/dmarc-report-analyzer)
-
+<ToolsCategoryGrid :tools="tools" />

--- a/tools/index.md
+++ b/tools/index.md
@@ -39,18 +39,8 @@ head:
       content: https://bluefox.email/assets/free-tools.png
 ---
 
-# Free Tools by BlueFox Email
+<script setup>
+import ToolsHome from '../.vitepress/theme/ToolsHome.vue'
+</script>
 
-Welcome to our toolbox, your gateway to a collection of **free online tools**. Currently, we offer comprehensive **email deliverability tools** to help you authenticate and secure your domains. We're actively expanding our toolkit and will soon include **pre-send tools** such as link checkers and email HTML validation tools to further enhance your email workflow.
-
-## Email Deliverability Tools
-
-Quickly check your domain’s email authentication setup with our DMARC, SPF, DKIM, and MX record checkers. Prevent spoofing, fix deliverability issues, and ensure your emails land in the inbox, not spam.
-
-[Explore Deliverability Tools →](/tools/deliverability/index)
-
-## Email Content Tools
-
-Ensure your email content is optimized for deliverability and engagement. Our tools help you analyze and improve your email copy, layout, and design.
-
-[Explore Content Tools →](/tools/content/index)
+<ToolsHome />


### PR DESCRIPTION
- Introduced ToolSwitcher.vue to allow users to switch between various email diagnostic tools (DMARC, SPF, DKIM, MX).
- Integrated dynamic URL generation based on user input for domain checks.

feat: enhance Turnstile component with readiness promise

- Added a readiness promise to the Turnstile component to ensure the widget is fully loaded before usage.
- Exposed the `whenReady` method for external use.

feat: update tools content pages with ToolsCategoryGrid component

- Refactored tools content pages to utilize ToolsCategoryGrid for better organization and presentation of tools.
- Added new tools (DMARC Checker, SPF Checker, DKIM Checker, MX Record Checker, DMARC Report Analyzer) with descriptions and icons.

refactor: streamline tools index page with ToolsHome component

- Replaced static content on tools index page with ToolsHome component for a cleaner and more maintainable structure.